### PR TITLE
Simplify radar card list hierarchy and mobile density

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
     <span class="category-chip">이사 준비</span><span class="category-chip">월세·전세 계약</span><span class="category-chip">통근 피로</span><span class="category-chip">생활권</span><span class="category-chip">밤길·소음·관리비</span><span class="category-chip">상가·권리금</span><span class="category-chip">현장 확인 질문</span>
   </div>
 </section>
-<section class="article-list mixed-list radar-latest-grid">
+<section class="article-list mixed-list radar-latest-grid radar-card-list">
   <div class="section-title"><h2>동네 레이더 최신 글</h2><p>계약 전 리스크와 현장 질문을 먼저 확인하세요.</p></div>
   <article class="list-card radar-card theme-night">
   <a class="radar-card-visual scene-night" href="/radar/station-to-home-night-route-check/" aria-label="역에서 집까지 마지막 7분, 밤길을 다시 보는 법">
@@ -113,7 +113,7 @@
 
     <p>서울·수도권 25~39세 전월세·이사 독자가 역세권 후보를 낮 지도 거리만으로 정하지 않도록 퇴근 후 마지막 7분의 조명·시야·멈춤 지점·우회 선택지…</p>
     <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">이사 준비</span> <span class="tag pale">전월세 계약</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
+    <p class="radar-card-checkpoint">체크포인트 3개</p>
     <a class="text-link" href="/radar/station-to-home-night-route-check/">레이더 열기 →</a>
   </div>
 </article>
@@ -136,7 +136,7 @@
 
     <p>전월세 후보를 볼 때 공동현관·우편함·택배·분리수거·공지판 신호를 30초 루프로 나눠 계속 보기, 다시 보기, 보류를 판단하는 동네 레이더 글.</p>
     <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">이사 준비</span> <span class="tag pale">전월세 계약</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
+    <p class="radar-card-checkpoint">체크포인트 3개</p>
     <a class="text-link" href="/radar/shared-entrance-management-signals/">레이더 열기 →</a>
   </div>
 </article>
@@ -160,7 +160,7 @@
 
     <p>반지하가 아닌 1층 전월세 후보를 볼 때 현관 앞 5m, 창문 시선, 수거·택배 동선, 우천 흔적, 야간 소음을 14분 루프로 나눠 계속 보기·다시…</p>
     <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">이사 준비</span> <span class="tag pale">전월세 계약</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
+    <p class="radar-card-checkpoint">체크포인트 3개</p>
     <a class="text-link" href="/radar/ground-floor-home-check/">레이더 열기 →</a>
   </div>
 </article>
@@ -184,7 +184,7 @@
 
     <p>서울·수도권 25~39세 전월세 독자가 엘리베이터 없는 4층 빌라를 볼 때 계단, 큰 짐, 택배, 분리수거, 밤 귀가를 12분 루프로 나눠 계속 보기…</p>
     <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">이사 준비</span> <span class="tag pale">전월세 계약</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
+    <p class="radar-card-checkpoint">체크포인트 3개</p>
     <a class="text-link" href="/radar/stair-only-fourth-floor-villa-check/">레이더 열기 →</a>
   </div>
 </article>

--- a/main.css
+++ b/main.css
@@ -179,6 +179,13 @@ h2 { letter-spacing: -0.035em; line-height: 1.18; }
 .radar-card h2 { margin: 2px 0 0; font-size: clamp(22px, 3vw, 31px); }
 .radar-card p { margin: 0; }
 .radar-card-hook { padding: 9px 11px; border-radius: 16px; background: #fff7ed; border: 1px solid #ffd2b8; color: #9a3412; font-size: 14px; line-height: 1.45; font-weight: 950; }
+
+.radar-card-checkpoint { margin: 2px 0 0; color: var(--orange-dark); font-size: 13px; font-weight: 900; }
+.radar-card-list .tag-row,
+.radar-card-list .radar-card-badge { display: none; }
+.radar-card-list .radar-card-body { gap: 10px; }
+.radar-card-list .radar-card .text-link { margin-top: 2px; }
+.radar-card-list .radar-card p { margin: 0; }
 .radar-card-actions { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 6px; }
 .radar-card-actions span { display: inline-flex; align-items: center; min-height: 30px; padding: 0 10px; border-radius: 999px; background: #fff7ed; border: 1px solid #ffd2b8; color: var(--orange-dark); font-size: 12px; font-weight: 950; }
 .radar-card .text-link { width: fit-content; min-height: 40px; margin-top: auto; padding: 0 13px; border-radius: 14px; background: var(--ink); color: #fff; text-decoration: none; box-shadow: 0 10px 22px rgba(33,25,34,.13); }
@@ -562,4 +569,12 @@ h2 { letter-spacing: -0.035em; line-height: 1.18; }
 }
 @media (max-width: 360px) {
   .nav { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+
+@media (max-width: 430px) {
+  .radar-card-list .radar-card h2 { display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+  .radar-card-list .radar-card p { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+  .radar-card-list .radar-card-checkpoint,
+  .radar-card-list .radar-card .text-link { display: inline-flex; }
 }

--- a/radar/index.html
+++ b/radar/index.html
@@ -71,7 +71,7 @@
     <span class="category-chip">예산·보증금·월세</span><span class="category-chip">관리비·교통비</span><span class="category-chip">통근·대체 생활권</span><span class="category-chip">생활 상권</span><span class="category-chip">밤길·소음</span><span class="category-chip">상가 임대차·권리금</span>
   </div>
 </section>
-<section class="article-list">
+<section class="article-list radar-card-list">
   <div class="section-title"><h2>공개된 동네 레이더 글</h2><p>각 글은 결론보다 “계약 전 무엇을 다시 확인할지”에 맞춰 읽으면 됩니다.</p></div>
   <article class="list-card radar-card theme-night">
   <a class="radar-card-visual scene-night" href="/radar/station-to-home-night-route-check/" aria-label="역에서 집까지 마지막 7분, 밤길을 다시 보는 법">
@@ -93,7 +93,7 @@
 
     <p>서울·수도권 25~39세 전월세·이사 독자가 역세권 후보를 낮 지도 거리만으로 정하지 않도록 퇴근 후 마지막 7분의 조명·시야·멈춤 지점·우회 선택지…</p>
     <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">이사 준비</span> <span class="tag pale">전월세 계약</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
+    <p class="radar-card-checkpoint">체크포인트 3개</p>
     <a class="text-link" href="/radar/station-to-home-night-route-check/">레이더 열기 →</a>
   </div>
 </article>
@@ -116,7 +116,7 @@
 
     <p>전월세 후보를 볼 때 공동현관·우편함·택배·분리수거·공지판 신호를 30초 루프로 나눠 계속 보기, 다시 보기, 보류를 판단하는 동네 레이더 글.</p>
     <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">이사 준비</span> <span class="tag pale">전월세 계약</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
+    <p class="radar-card-checkpoint">체크포인트 3개</p>
     <a class="text-link" href="/radar/shared-entrance-management-signals/">레이더 열기 →</a>
   </div>
 </article>
@@ -140,7 +140,7 @@
 
     <p>반지하가 아닌 1층 전월세 후보를 볼 때 현관 앞 5m, 창문 시선, 수거·택배 동선, 우천 흔적, 야간 소음을 14분 루프로 나눠 계속 보기·다시…</p>
     <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">이사 준비</span> <span class="tag pale">전월세 계약</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
+    <p class="radar-card-checkpoint">체크포인트 3개</p>
     <a class="text-link" href="/radar/ground-floor-home-check/">레이더 열기 →</a>
   </div>
 </article>
@@ -164,7 +164,7 @@
 
     <p>서울·수도권 25~39세 전월세 독자가 엘리베이터 없는 4층 빌라를 볼 때 계단, 큰 짐, 택배, 분리수거, 밤 귀가를 12분 루프로 나눠 계속 보기…</p>
     <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">이사 준비</span> <span class="tag pale">전월세 계약</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
+    <p class="radar-card-checkpoint">체크포인트 3개</p>
     <a class="text-link" href="/radar/stair-only-fourth-floor-villa-check/">레이더 열기 →</a>
   </div>
 </article>
@@ -187,7 +187,7 @@
 
     <p>서울·수도권 25~39세 전월세·이사 독자가 아침 8시 후보지를 다시 볼 때 등교, 수거, 출근, 공용부 대기를 내 루틴과 분리해 계속 보기·다시 보…</p>
     <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">이사 준비</span> <span class="tag pale">전월세 계약</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
+    <p class="radar-card-checkpoint">체크포인트 3개</p>
     <a class="text-link" href="/radar/morning-routine-neighborhood-check/">레이더 열기 →</a>
   </div>
 </article>
@@ -211,7 +211,7 @@
 
     <p>서울·수도권 25~39세 전월세·이사 독자가 밤 10시 전후 후보지를 다시 볼 때 큰길·골목·공용부·창가 소리를 나누고 계속 보기·다시 보기·보류 질…</p>
     <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">이사 준비</span> <span class="tag pale">전월세 계약</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
+    <p class="radar-card-checkpoint">체크포인트 3개</p>
     <a class="text-link" href="/radar/night-noise-walk-check/">레이더 열기 →</a>
   </div>
 </article>
@@ -235,7 +235,7 @@
 
     <p>전월세 후보를 비 오는 날 볼 때 실내 습기, 공용부 물기, 골목 배수, 우산 동선을 나눠 기록하고 계속 볼지, 맑은 날 다시 볼지, 보류 질문을 남…</p>
     <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">이사 준비</span> <span class="tag pale">전월세 계약</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
+    <p class="radar-card-checkpoint">체크포인트 3개</p>
     <a class="text-link" href="/radar/rainy-day-viewing-neighborhood-signals/">레이더 열기 →</a>
   </div>
 </article>
@@ -260,7 +260,7 @@
     <p class="radar-card-hook">오늘의 의심 · 최단시간 착시: 앱은 35분이라는데 몸은 매일 50분짜리 피로를 기억한다.</p>
     <p>지도앱 최단시간만 보면 줄 서는 정류장, 긴 환승 통로, 비 오는 날 마지막 도보, 야근 후 우회길이 빠진다. 서울·수도권 전월세 후보를 계약 전 1…</p>
     <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">이사 준비</span> <span class="tag pale">전월세 계약</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
+    <p class="radar-card-checkpoint">체크포인트 3개</p>
     <a class="text-link" href="/radar/commute-fatigue-neighborhood-check/">레이더 열기 →</a>
   </div>
 </article>
@@ -284,7 +284,7 @@
     <p class="radar-card-hook">오늘의 의심 · 낮사진 사기: 방은 멀쩡한데 내가 실제로 사는 시간대가 비어 있다.</p>
     <p>낮 사진과 낮 방문만 믿으면 퇴근길 조도, 마지막 골목, 건물 입구 대기감, 밤소음이 빠진다. 서울·수도권 전월세 후보를 계약 전 20분 다시 걸으며…</p>
     <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">이사 준비</span> <span class="tag pale">전월세 계약</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
+    <p class="radar-card-checkpoint">체크포인트 3개</p>
     <a class="text-link" href="/radar/after-work-neighborhood-check/">레이더 열기 →</a>
   </div>
 </article>
@@ -307,7 +307,7 @@
     <p class="radar-card-hook">오늘의 의심 · 관리비 블랙박스: 월세는 낮은데 매달 빠지는 돈의 정체가 안 보인다.</p>
     <p>월세가 낮아 보여도 관리비 포함 항목이 흐리면 실제 고정비는 달라진다. 전기·수도·가스·인터넷·청소·공용관리 중 무엇이 빠졌는지 묻고, 답이 흐린 월…</p>
     <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">이사 준비</span> <span class="tag pale">전월세 계약</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
+    <p class="radar-card-checkpoint">체크포인트 3개</p>
     <a class="text-link" href="/radar/maintenance-fee-opaque-rent/">레이더 열기 →</a>
   </div>
 </article>
@@ -330,7 +330,7 @@
     <p class="radar-card-hook">오늘의 의심 · 월세 착시: 싸 보이는 숫자가 생활비와 피로를 다른 줄로 숨긴다.</p>
     <p>월세가 5만 원 낮아도 보증금, 관리비, 통근, 장보기·병원·세탁 동선이 나빠지면 생활비와 피로가 더 커질 수 있다. 계약 전 낮은 월세 착시를 잡는…</p>
     <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">이사 준비</span> <span class="tag pale">전월세 계약</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
+    <p class="radar-card-checkpoint">체크포인트 3개</p>
     <a class="text-link" href="/radar/monthly-rent-pressure-questions/">레이더 열기 →</a>
   </div>
 </article>
@@ -353,7 +353,7 @@
     <p class="radar-card-hook">오늘의 의심 · 후보 과잉 착시: 많이 저장할수록 똑똑해진 것 같지만, 결정은 더 흐려진다.</p>
     <p>좋은 동네를 찾기 전에 안 맞는 후보를 줄여야 한다. 예산, 통근, 인구 신호, 생활 상권, 현장 질문을 묶어 서울·수도권 월세·전세 후보를 계약 전…</p>
     <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">이사 준비</span> <span class="tag pale">전월세 계약</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
+    <p class="radar-card-checkpoint">체크포인트 3개</p>
     <a class="text-link" href="/radar/dongne-signal-framework/">레이더 열기 →</a>
   </div>
 </article>
@@ -377,7 +377,7 @@
     <p class="radar-card-hook">오늘의 의심 · 유동인구 착시: 사람이 많은 것과 내 카페에 돈을 쓰는 것은 다르다.</p>
     <p>유동인구가 많아도 카페가 이미 많고, 권리금 회수 기간이 길고, 시간대가 안 맞으면 좋은 자리가 아닐 수 있다. 서울 카페 창업·상가 계약 전 사람…</p>
     <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">카페 창업</span> <span class="tag pale">상권 분석</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
+    <p class="radar-card-checkpoint">체크포인트 3개</p>
     <a class="text-link" href="/radar/cafe-contract-risk/">레이더 열기 →</a>
   </div>
 </article>


### PR DESCRIPTION
### Motivation
- Reduce visual noise in list views so each radar card prioritizes `제목 > 한줄 요약 > CTA` for faster scanning. 
- Surface only the most useful metadata on list pages and keep secondary/decorative badges/tags for detail pages. 
- Replace three separate action chips with a single compact summary to lower cognitive load. 
- Limit text lines on small screens (320–430px) to reduce scrolling and reading fatigue.

### Description
- Updated `index.html` and `radar/index.html` to add a shared list context class `radar-card-list` and replaced the three-chip action row with a single element `<p class="radar-card-checkpoint">체크포인트 3개</p>` inside each list card. 
- Added CSS rules in `main.css` including `.radar-card-checkpoint`, `.radar-card-list .tag-row` and `.radar-card-list .radar-card-badge { display: none; }`, reduced internal gaps for list cards, and tightened the `text-link` spacing. 
- Added a mobile media query (`@media (max-width: 430px)`) that clamps list card titles to 2 lines and summaries to 3 lines using `-webkit-line-clamp` to limit per-card text density. 
- Unified list/home latest-grid rendering by using the `radar-card-list` wrapper to reduce component variants and keep detail-only elements available on article pages.

### Testing
- Searched for affected selectors and occurrences with `rg` to ensure all list instances were updated. 
- Inspected updated markup with `sed`/`nl` on `index.html` and `radar/index.html` to confirm `radar-card-list` and checkpoint text replacements. 
- Verified CSS additions and the mobile media query by viewing `main.css` slices with `sed`/`nl` and ensuring the new rules are present. 
- Reviewed the code diff to confirm only the intended lines were changed and the list layout/line-clamp rules are added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f85877824c83249b3f4cf74ac0214e)