### PR TITLE
Refocus homepage funnel toward /radar/ (single CTA, latest 3, accordion, metrics)

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,39 +60,17 @@
   <h1>이사·월세·상가 계약 전, 동네 리스크부터 걸러냅니다.</h1>
   <p class="lead">동네 레이더는 “여기가 좋다”가 아니라 내 계약 조건에서 피해야 할 신호와 현장에서 다시 물어볼 질문을 먼저 정리합니다.</p>
   <div class="hero-actions">
-    <a class="button primary" href="/radar/">동네 레이더 먼저 보기</a>
-    <a class="button" href="/guides/">읽는 순서 보기</a>
-    <a class="button" href="/deals/">구매가이드 별도 보기</a>
+    <a class="button primary" href="/radar/" data-cta-role="primary-radar">레이더 보기</a>
   </div>
+  <p class="hero-links" aria-label="보조 링크">
+    <a class="text-link" href="/guides/">읽는 순서 보기</a>
+    <span aria-hidden="true">·</span>
+    <a class="text-link" href="/deals/">분리 운영 구매가이드</a>
+  </p>
 </section>
-<section class="grid three">
-  <article class="card accent-blue">
-    <span class="tag">Primary</span>
-    <h2>동네 레이더</h2>
-    <p>월세·전세 계약, 통근 피로, 생활권, 밤길·소음·관리비, 상가 권리금 리스크를 계약 전 질문으로 바꿉니다.</p>
-    <a href="/radar/">/radar/ 열기 →</a>
-  </article>
-  <article class="card accent-green">
-    <span class="tag">Guide</span>
-    <h2>처음 읽는 순서</h2>
-    <p>이사 준비, 상가 계약, 생활 구매를 섞지 않고 목적별로 어떤 글을 먼저 볼지 정리합니다.</p>
-    <a href="/guides/">가이드 보기 →</a>
-  </article>
-  <article class="card accent-orange">
-    <span class="tag">Separate</span>
-    <h2>구매가이드는 분리</h2>
-    <p>생활 상품 비교는 /deals/에서만 다룹니다. 동네 레이더 글에는 제휴 문맥을 섞지 않습니다.</p>
-    <a href="/deals/">구매가이드 보기 →</a>
-  </article>
-</section>
-<section class="panel soft">
-  <h2>동네 레이더가 보는 범위</h2>
-  <div class="category-strip">
-    <span class="category-chip">이사 준비</span><span class="category-chip">월세·전세 계약</span><span class="category-chip">통근 피로</span><span class="category-chip">생활권</span><span class="category-chip">밤길·소음·관리비</span><span class="category-chip">상가·권리금</span><span class="category-chip">현장 확인 질문</span>
-  </div>
-</section>
+
 <section class="article-list mixed-list radar-latest-grid">
-  <div class="section-title"><h2>동네 레이더 최신 글</h2><p>계약 전 리스크와 현장 질문을 먼저 확인하세요.</p></div>
+  <div class="section-title"><h2>최신 레이더 3개</h2><p>스크롤 1~2번 안에서 바로 확인하고 판단할 수 있게 최신 글만 먼저 보여줍니다.</p></div>
   <article class="list-card radar-card theme-night">
   <a class="radar-card-visual scene-night" href="/radar/station-to-home-night-route-check/" aria-label="역에서 집까지 마지막 7분, 밤길을 다시 보는 법">
     <span class="radar-thumb-label">CASE</span>
@@ -164,33 +142,39 @@
     <a class="text-link" href="/radar/ground-floor-home-check/">레이더 열기 →</a>
   </div>
 </article>
-<article class="list-card radar-card theme-night">
-  <a class="radar-card-visual scene-night" href="/radar/stair-only-fourth-floor-villa-check/" aria-label="엘리베이터 없는 4층 빌라, 계속 볼지 보류할지 보는 12분">
-    <span class="radar-thumb-label">CASE</span>
-    <strong class="radar-thumb-title">밤에 다시 보기</strong>
-    <span class="radar-thumb-subline">낮사진을 의심</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art night-art">
-      <span class="lamp-post"></span><span class="lamp-light"></span><span class="alley-road"></span>
-      <span class="window-stack"></span><span class="noise-wave wave-one"></span><span class="noise-wave wave-two"></span>
-      <span class="street-chip chip-a">출구</span><span class="street-chip chip-b">골목</span><span class="street-chip chip-c">소음</span>
-    </span>
-    </span>
-    <span class="radar-card-badge">밤길 수사</span>
-  </a>
-  <div class="radar-card-body">
-    <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-05-03T04:36:25+09:00">05.03</time></div>
-    <h2><a href="/radar/stair-only-fourth-floor-villa-check/">엘리베이터 없는 4층 빌라, 계속 볼지 보류할지 보는 12분</a></h2>
-
-    <p>서울·수도권 25~39세 전월세 독자가 엘리베이터 없는 4층 빌라를 볼 때 계단, 큰 짐, 택배, 분리수거, 밤 귀가를 12분 루프로 나눠 계속 보기…</p>
-    <div class="tag-row"><span class="tag pale">동네 레이더</span> <span class="tag pale">이사 준비</span> <span class="tag pale">전월세 계약</span></div>
-    <div class="radar-card-actions"><span>오늘의 의심</span><span>현장 미션</span><span>판정 기준</span></div>
-    <a class="text-link" href="/radar/stair-only-fourth-floor-villa-check/">레이더 열기 →</a>
-  </div>
-</article>
 </section>
+<section class="grid three">
+  <article class="card accent-blue">
+    <span class="tag">Primary</span>
+    <h2>동네 레이더</h2>
+    <p>월세·전세 계약, 통근 피로, 생활권, 밤길·소음·관리비, 상가 권리금 리스크를 계약 전 질문으로 바꿉니다.</p>
+    <a href="/radar/">/radar/ 열기 →</a>
+  </article>
+  <article class="card accent-green">
+    <span class="tag">Guide</span>
+    <h2>처음 읽는 순서</h2>
+    <p>이사 준비, 상가 계약, 생활 구매를 섞지 않고 목적별로 어떤 글을 먼저 볼지 정리합니다.</p>
+    <a href="/guides/">가이드 보기 →</a>
+  </article>
+  <article class="card accent-orange">
+    <span class="tag">Separate</span>
+    <h2>구매가이드는 분리</h2>
+    <p>생활 상품 비교는 /deals/에서만 다룹니다. 동네 레이더 글에는 제휴 문맥을 섞지 않습니다.</p>
+    <a href="/deals/">구매가이드 보기 →</a>
+  </article>
+</section>
+<section class="panel soft">
+  <h2>동네 레이더가 보는 범위</h2>
+  <details class="category-accordion">
+    <summary>핵심 범위 보기</summary>
+    <div class="category-strip">
+      <span class="category-chip">이사 준비</span><span class="category-chip">월세·전세 계약</span><span class="category-chip">통근 피로</span><span class="category-chip">생활권</span><span class="category-chip">밤길·소음·관리비</span><span class="category-chip">상가·권리금</span><span class="category-chip">현장 확인 질문</span>
+    </div>
+  </details>
+</section>
+
 <section class="article-list mixed-list">
-  <div class="section-title"><h2>분리 운영 중인 구매가이드</h2><p>상품 비교가 필요할 때만 별도 섹션에서 확인합니다.</p></div>
+  <div class="section-title"><h2>분리 운영 중인 구매가이드</h2><p>분리 운영 안내만 유지합니다. 상품 비교가 필요할 때만 별도 섹션에서 확인합니다.</p></div>
   <article class="deal-card">
   <a class="deal-thumb" href="/deals/wireless-stick-vacuum-top4-2026/" aria-label="무선청소기·스틱청소기 4종 비교, 자동 먼지 비움부터 흡입력까지 구매가이드">
     <img src="https://thumbnail.coupangcdn.com/thumbnails/remote/657x657q90trim/image/vendor_inventory/1431/6767e474eae83ef652c5efbab3a2f316b88973349e274ffda340d536ed9e.jpg" alt="무선청소기·스틱청소기 4종 비교, 자동 먼지 비움부터 흡입력까지 구매가이드 대표 상품 이미지" loading="lazy" decoding="async" />
@@ -207,38 +191,15 @@
     </div>
   </div>
 </article>
-<article class="deal-card">
-  <a class="deal-thumb" href="/deals/2026-블루투스-스피커-추천-top-5-jbl-보스-마샬-실사용-비교-5aa2cfcf/" aria-label="2026 블루투스 스피커 추천 TOP 5 JBL·보스·마샬 실사용 비교">
-    <img src="https://www.jbl.com.ar/dw/image/v2/AAUJ_PRD/on/demandware.static/-/Sites-masterCatalog_Harman/default/dwdac021cb/1_JBL_FLIP6_HERO_WHITE_29399_x1.png?sw=400&amp;sh=400&amp;sm=fit&amp;sfrm=png" alt="2026 블루투스 스피커 추천 TOP 5 JBL·보스·마샬 실사용 비교 대표 상품 이미지" loading="lazy" decoding="async" />
-    <span class="deal-count">5개 후보 비교</span>
+</section>
 
-  </a>
-  <div class="deal-body">
-    <div class="deal-meta"><span>이어폰-헤드셋</span><time datetime="2026-05-01T17:14:47+09:00">05.01</time><span class="traffic-badge" title="최근 30일 조회 데이터">👁 최근 30일 1회 · 방문 1</span></div>
-    <h2><a href="/deals/2026-블루투스-스피커-추천-top-5-jbl-보스-마샬-실사용-비교-5aa2cfcf/">2026 블루투스 스피커 추천 TOP 5 JBL·보스·마샬 실사용 비교</a></h2>
-    <p>JBL Flip 6·Charge 5, 보스 SoundLink Flex, 마샬 Emberton II, 소니 ULT FIELD 1 가격대별 비교. 방수 등급·배터리·음…</p>
-    <div class="deal-price"><span>상세가는 상품 페이지에서 확인</span><a class="deal-price-link" href="https://www.coupang.com/vp/products/7047907571?lptag=AF3961595" target="_blank" rel="sponsored nofollow noopener">가격 확인</a></div>
-    <div class="deal-actions">
-      <a class="deal-button primary" href="/deals/2026-블루투스-스피커-추천-top-5-jbl-보스-마샬-실사용-비교-5aa2cfcf/">비교글 보기</a>
-    </div>
-  </div>
-</article>
-<article class="deal-card">
-  <a class="deal-thumb" href="/deals/beauty-personal-care-gadgets-top5/" aria-label="잘 팔리는 뷰티·퍼스널케어 가전 5선, 선물용으로도 좋은 제품 추천 비교">
-    <img src="https://thumbnail.coupangcdn.com/thumbnails/remote/657x657q90trim/image/retail/images/145235857960113-16d79be5-2580-4dfd-a4ec-23e192915aea.jpg" alt="잘 팔리는 뷰티·퍼스널케어 가전 5선, 선물용으로도 좋은 제품 추천 비교 대표 상품 이미지" loading="lazy" decoding="async" />
-    <span class="deal-count">5개 후보 비교</span>
-
-  </a>
-  <div class="deal-body">
-    <div class="deal-meta"><span>오늘의딜</span><time datetime="2026-04-29T19:26:00+09:00">04.29</time><span class="traffic-badge" title="최근 30일 조회 데이터">👁 최근 30일 1회 · 방문 1</span></div>
-    <h2><a href="/deals/beauty-personal-care-gadgets-top5/">잘 팔리는 뷰티·퍼스널케어 가전 5선, 선물용으로도 좋은 제품 추천 비교</a></h2>
-    <p>뷰티·퍼스널케어 가전은 선물용인지 매일 쓰는 관리용인지에 따라 봐야 할 기준이 달라집니다. 전동칫솔, 헤어드라이어, 피부관리 기기처럼 후기 흐름과 소모품·사용 빈도…</p>
-    <div class="deal-price"><span>19~29만원 수준</span><a class="deal-price-link" href="https://www.coupang.com/vp/products/7183697050?lptag=AF3961595" target="_blank" rel="sponsored nofollow noopener">가격 확인</a></div>
-    <div class="deal-actions">
-      <a class="deal-button primary" href="/deals/beauty-personal-care-gadgets-top5/">비교글 보기</a>
-    </div>
-  </div>
-</article>
+<section class="panel soft funnel-metric">
+  <h2>사용자 동선 점검 지표</h2>
+  <p>스크롤 1~2번 내 행동이 <strong>레이더 보기</strong>로 수렴되는지 아래 지표로 점검합니다.</p>
+  <ul>
+    <li>첫 화면 1차 CTA 클릭률: <code>레이더 보기</code> 클릭 / 첫 화면 진입 세션</li>
+    <li>체류 시작점: 첫 클릭 또는 첫 30초 내 머문 섹션에서 <code>/radar/</code> 진입 비율</li>
+  </ul>
 </section>
 
   </main>

--- a/main.css
+++ b/main.css
@@ -81,6 +81,8 @@ h1 { font-size: clamp(40px, 7vw, 76px); line-height: 1.04; letter-spacing: -0.05
 h2 { letter-spacing: -0.035em; line-height: 1.18; }
 .lead { color: #5f5652; font-size: clamp(18px, 2.1vw, 23px); max-width: 850px; }
 .hero-actions { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 28px; }
+.hero-links { margin-top: 12px; display: flex; gap: 8px; align-items: center; color: var(--muted); }
+.hero-links .text-link { font-weight: 700; }
 .button, .deal-button {
   display: inline-flex; align-items: center; justify-content: center;
   min-height: 48px; padding: 0 18px; border-radius: 16px;
@@ -258,6 +260,8 @@ h2 { letter-spacing: -0.035em; line-height: 1.18; }
 }
 .shop-hero-copy h1 { max-width: 760px; }
 .category-strip { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 24px; }
+.category-accordion summary { cursor: pointer; font-weight: 850; color: var(--ink); }
+.category-accordion[open] summary { margin-bottom: 4px; }
 .category-chip { display: inline-flex; padding: 8px 12px; border-radius: 999px; background: #fff; border: 1px solid var(--line); color: #4b423f; font-weight: 900; font-size: 13px; }
 .hero-pin-stack { position: relative; min-height: 380px; }
 .hero-pin { position: absolute; display: block; width: 58%; overflow: hidden; border-radius: 30px; background: #fff; box-shadow: var(--shadow); border: 8px solid #fff; }


### PR DESCRIPTION
### Motivation
- Reduce message conflict above the fold and make the primary user action unambiguous by focusing early attention on the radar experience (`/radar/`).
- Surface a small, actionable feed so users can decide within 1–2 scrolls whether to open a radar case.
- De-emphasize the 구매가이드 content on first view to avoid mixed signals and preserve it as a separate, discoverable area.

### Description
- Locked the hero primary CTA to a single button `레이더 보기` that links to `/radar/` and added `data-cta-role="primary-radar"` for tracking, while downgrading previous hero buttons to text links (`.hero-links`) in `index.html`.
- Moved the radar feed directly under the hero and trimmed the feed to the latest 3 radar cards (`최신 레이더 3개`) to keep the first 1–2 scrolls focused on the radar action in `index.html`.
- Relocated the intro cards (`Primary/Guide/Separate`) below the radar block and reduced the 구매가이드 exposure to a single deal card with explanatory copy emphasizing split operation in `index.html`.
- Converted the chip list (`동네 레이더가 보는 범위`) into a collapsible `details/summary` accordion (`.category-accordion`) to compact that area in `index.html` and added corresponding CSS rules in `main.css`.
- Added a new funnel metric panel (`.funnel-metric`) describing two measurable metrics to verify whether the early-page action funnels to `레이더 보기` (first-CTA click rate and stay/start-point -> `/radar/` entry rate) in `index.html`.
- Style updates in `main.css` to support `.hero-links` and `.category-accordion` visual behavior.

### Testing
- Verified presence and placement changes by searching modified strings with `rg` (e.g. `rg -n "hero-links|최신 레이더 3개|category-accordion|사용자 동선 점검 지표|분리 운영 안내만" index.html main.css`) which returned the expected matches (success).
- Previewed the modified `index.html` and `main.css` snippets with `sed`/`nl` to confirm the new sections and CSS rules appear at the intended locations (success).
- Ran a workspace-level file status check to confirm `index.html` and `main.css` were updated (file diffs inspected via output) (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f858810adc83249d191e513011115c)