### PR TITLE
Standardize radar cover assets and replace DOM thumbnail art with image covers

### DIFF
--- a/assets/radar/after-work-neighborhood-check/visuals/after-work-neighborhood-check-card.svg
+++ b/assets/radar/after-work-neighborhood-check/visuals/after-work-neighborhood-check-card.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="t d">
+<title id="t">퇴근 후 20분 수사 · 낮 사진 재검증</title><desc id="d">Dongne Radar cover for after-work-neighborhood-check</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0f172a"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="640" height="360" fill="url(#g)" rx="28"/>
+<rect x="32.0" y="43.2" width="576.0" height="273.6" rx="24" fill="none" stroke="#38bdf8" stroke-opacity="0.35"/>
+<text x="51.2" y="97.2" fill="#38bdf8" font-size="28.8" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="51.2" y="172.8" fill="#f8fafc" font-size="36.0" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">퇴근 후 20분 수사</text>
+<text x="51.2" y="223.2" fill="#cbd5e1" font-size="25.2" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">낮 사진 재검증</text>
+<path d="M 473.6 201.6 L 576.0 201.6 M 473.6 223.2 L 576.0 223.2 M 473.6 244.8 L 576.0 244.8" stroke="#38bdf8" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/assets/radar/after-work-neighborhood-check/visuals/after-work-neighborhood-check-og.svg
+++ b/assets/radar/after-work-neighborhood-check/visuals/after-work-neighborhood-check-og.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="t d">
+<title id="t">퇴근 후 20분 수사 · 낮 사진 재검증</title><desc id="d">Dongne Radar cover for after-work-neighborhood-check</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0f172a"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="1200" height="675" fill="url(#g)" rx="28"/>
+<rect x="60.0" y="81.0" width="1080.0" height="513.0" rx="24" fill="none" stroke="#38bdf8" stroke-opacity="0.35"/>
+<text x="96.0" y="182.2" fill="#38bdf8" font-size="54.0" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="96.0" y="324.0" fill="#f8fafc" font-size="67.5" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">퇴근 후 20분 수사</text>
+<text x="96.0" y="418.5" fill="#cbd5e1" font-size="47.3" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">낮 사진 재검증</text>
+<path d="M 888.0 378.0 L 1080.0 378.0 M 888.0 418.5 L 1080.0 418.5 M 888.0 459.0 L 1080.0 459.0" stroke="#38bdf8" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/assets/radar/cafe-contract-risk/visuals/cafe-contract-risk-card.svg
+++ b/assets/radar/cafe-contract-risk/visuals/cafe-contract-risk-card.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="t d">
+<title id="t">카페 계약 5의심 · 유동·체류·임대조건</title><desc id="d">Dongne Radar cover for cafe-contract-risk</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#1f2937"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="640" height="360" fill="url(#g)" rx="28"/>
+<rect x="32.0" y="43.2" width="576.0" height="273.6" rx="24" fill="none" stroke="#f59e0b" stroke-opacity="0.35"/>
+<text x="51.2" y="97.2" fill="#f59e0b" font-size="28.8" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="51.2" y="172.8" fill="#f8fafc" font-size="36.0" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">카페 계약 5의심</text>
+<text x="51.2" y="223.2" fill="#cbd5e1" font-size="25.2" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">유동·체류·임대조건</text>
+<rect x="492.8" y="72.0" width="96.0" height="86.4" rx="14" stroke="#f59e0b" fill="none" stroke-width="6"/><path d="M 588.8 97.2 q 32.0 10.8 0 32.4" stroke="#f59e0b" fill="none" stroke-width="6"/>
+</svg>

--- a/assets/radar/cafe-contract-risk/visuals/cafe-contract-risk-og.svg
+++ b/assets/radar/cafe-contract-risk/visuals/cafe-contract-risk-og.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="t d">
+<title id="t">카페 계약 5의심 · 유동·체류·임대조건</title><desc id="d">Dongne Radar cover for cafe-contract-risk</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#1f2937"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="1200" height="675" fill="url(#g)" rx="28"/>
+<rect x="60.0" y="81.0" width="1080.0" height="513.0" rx="24" fill="none" stroke="#f59e0b" stroke-opacity="0.35"/>
+<text x="96.0" y="182.2" fill="#f59e0b" font-size="54.0" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="96.0" y="324.0" fill="#f8fafc" font-size="67.5" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">카페 계약 5의심</text>
+<text x="96.0" y="418.5" fill="#cbd5e1" font-size="47.3" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">유동·체류·임대조건</text>
+<rect x="924.0" y="135.0" width="180.0" height="162.0" rx="14" stroke="#f59e0b" fill="none" stroke-width="6"/><path d="M 1104.0 182.2 q 60.0 20.2 0 60.8" stroke="#f59e0b" fill="none" stroke-width="6"/>
+</svg>

--- a/assets/radar/commute-fatigue-neighborhood-check/visuals/commute-fatigue-neighborhood-check-card.svg
+++ b/assets/radar/commute-fatigue-neighborhood-check/visuals/commute-fatigue-neighborhood-check-card.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="t d">
+<title id="t">출근길 피로 15분 · 앱 시간의 사각지대</title><desc id="d">Dongne Radar cover for commute-fatigue-neighborhood-check</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#1f2937"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="640" height="360" fill="url(#g)" rx="28"/>
+<rect x="32.0" y="43.2" width="576.0" height="273.6" rx="24" fill="none" stroke="#f59e0b" stroke-opacity="0.35"/>
+<text x="51.2" y="97.2" fill="#f59e0b" font-size="28.8" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="51.2" y="172.8" fill="#f8fafc" font-size="36.0" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">출근길 피로 15분</text>
+<text x="51.2" y="223.2" fill="#cbd5e1" font-size="25.2" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">앱 시간의 사각지대</text>
+<path d="M 473.6 201.6 L 576.0 201.6 M 473.6 223.2 L 576.0 223.2 M 473.6 244.8 L 576.0 244.8" stroke="#f59e0b" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/assets/radar/commute-fatigue-neighborhood-check/visuals/commute-fatigue-neighborhood-check-og.svg
+++ b/assets/radar/commute-fatigue-neighborhood-check/visuals/commute-fatigue-neighborhood-check-og.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="t d">
+<title id="t">출근길 피로 15분 · 앱 시간의 사각지대</title><desc id="d">Dongne Radar cover for commute-fatigue-neighborhood-check</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#1f2937"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="1200" height="675" fill="url(#g)" rx="28"/>
+<rect x="60.0" y="81.0" width="1080.0" height="513.0" rx="24" fill="none" stroke="#f59e0b" stroke-opacity="0.35"/>
+<text x="96.0" y="182.2" fill="#f59e0b" font-size="54.0" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="96.0" y="324.0" fill="#f8fafc" font-size="67.5" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">출근길 피로 15분</text>
+<text x="96.0" y="418.5" fill="#cbd5e1" font-size="47.3" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">앱 시간의 사각지대</text>
+<path d="M 888.0 378.0 L 1080.0 378.0 M 888.0 418.5 L 1080.0 418.5 M 888.0 459.0 L 1080.0 459.0" stroke="#f59e0b" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/assets/radar/dongne-signal-framework/visuals/dongne-signal-framework-card.svg
+++ b/assets/radar/dongne-signal-framework/visuals/dongne-signal-framework-card.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="t d">
+<title id="t">동네 후보 축소법 · 신호→질문→판단</title><desc id="d">Dongne Radar cover for dongne-signal-framework</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#052e16"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="640" height="360" fill="url(#g)" rx="28"/>
+<rect x="32.0" y="43.2" width="576.0" height="273.6" rx="24" fill="none" stroke="#4ade80" stroke-opacity="0.35"/>
+<text x="51.2" y="97.2" fill="#4ade80" font-size="28.8" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="51.2" y="172.8" fill="#f8fafc" font-size="36.0" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">동네 후보 축소법</text>
+<text x="51.2" y="223.2" fill="#cbd5e1" font-size="25.2" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">신호→질문→판단</text>
+<path d="M 473.6 201.6 L 576.0 201.6 M 473.6 223.2 L 576.0 223.2 M 473.6 244.8 L 576.0 244.8" stroke="#4ade80" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/assets/radar/dongne-signal-framework/visuals/dongne-signal-framework-og.svg
+++ b/assets/radar/dongne-signal-framework/visuals/dongne-signal-framework-og.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="t d">
+<title id="t">동네 후보 축소법 · 신호→질문→판단</title><desc id="d">Dongne Radar cover for dongne-signal-framework</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#052e16"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="1200" height="675" fill="url(#g)" rx="28"/>
+<rect x="60.0" y="81.0" width="1080.0" height="513.0" rx="24" fill="none" stroke="#4ade80" stroke-opacity="0.35"/>
+<text x="96.0" y="182.2" fill="#4ade80" font-size="54.0" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="96.0" y="324.0" fill="#f8fafc" font-size="67.5" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">동네 후보 축소법</text>
+<text x="96.0" y="418.5" fill="#cbd5e1" font-size="47.3" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">신호→질문→판단</text>
+<path d="M 888.0 378.0 L 1080.0 378.0 M 888.0 418.5 L 1080.0 418.5 M 888.0 459.0 L 1080.0 459.0" stroke="#4ade80" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/assets/radar/ground-floor-home-check/visuals/ground-floor-home-check-card.svg
+++ b/assets/radar/ground-floor-home-check/visuals/ground-floor-home-check-card.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="t d">
+<title id="t">1층집 14분 루프 · 시선·소음·우천 흔적</title><desc id="d">Dongne Radar cover for ground-floor-home-check</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0f172a"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="640" height="360" fill="url(#g)" rx="28"/>
+<rect x="32.0" y="43.2" width="576.0" height="273.6" rx="24" fill="none" stroke="#38bdf8" stroke-opacity="0.35"/>
+<text x="51.2" y="97.2" fill="#38bdf8" font-size="28.8" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="51.2" y="172.8" fill="#f8fafc" font-size="36.0" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">1층집 14분 루프</text>
+<text x="51.2" y="223.2" fill="#cbd5e1" font-size="25.2" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">시선·소음·우천 흔적</text>
+<path d="M 473.6 201.6 L 576.0 201.6 M 473.6 223.2 L 576.0 223.2 M 473.6 244.8 L 576.0 244.8" stroke="#38bdf8" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/assets/radar/ground-floor-home-check/visuals/ground-floor-home-check-og.svg
+++ b/assets/radar/ground-floor-home-check/visuals/ground-floor-home-check-og.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="t d">
+<title id="t">1층집 14분 루프 · 시선·소음·우천 흔적</title><desc id="d">Dongne Radar cover for ground-floor-home-check</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0f172a"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="1200" height="675" fill="url(#g)" rx="28"/>
+<rect x="60.0" y="81.0" width="1080.0" height="513.0" rx="24" fill="none" stroke="#38bdf8" stroke-opacity="0.35"/>
+<text x="96.0" y="182.2" fill="#38bdf8" font-size="54.0" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="96.0" y="324.0" fill="#f8fafc" font-size="67.5" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">1층집 14분 루프</text>
+<text x="96.0" y="418.5" fill="#cbd5e1" font-size="47.3" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">시선·소음·우천 흔적</text>
+<path d="M 888.0 378.0 L 1080.0 378.0 M 888.0 418.5 L 1080.0 418.5 M 888.0 459.0 L 1080.0 459.0" stroke="#38bdf8" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/assets/radar/maintenance-fee-opaque-rent/visuals/maintenance-fee-opaque-rent-card.svg
+++ b/assets/radar/maintenance-fee-opaque-rent/visuals/maintenance-fee-opaque-rent-card.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="t d">
+<title id="t">관리비 블랙박스 · 항목·고지·증빙 확인</title><desc id="d">Dongne Radar cover for maintenance-fee-opaque-rent</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#052e16"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="640" height="360" fill="url(#g)" rx="28"/>
+<rect x="32.0" y="43.2" width="576.0" height="273.6" rx="24" fill="none" stroke="#4ade80" stroke-opacity="0.35"/>
+<text x="51.2" y="97.2" fill="#4ade80" font-size="28.8" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="51.2" y="172.8" fill="#f8fafc" font-size="36.0" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">관리비 블랙박스</text>
+<text x="51.2" y="223.2" fill="#cbd5e1" font-size="25.2" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">항목·고지·증빙 확인</text>
+<path d="M 473.6 201.6 L 576.0 201.6 M 473.6 223.2 L 576.0 223.2 M 473.6 244.8 L 576.0 244.8" stroke="#4ade80" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/assets/radar/maintenance-fee-opaque-rent/visuals/maintenance-fee-opaque-rent-og.svg
+++ b/assets/radar/maintenance-fee-opaque-rent/visuals/maintenance-fee-opaque-rent-og.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="t d">
+<title id="t">관리비 블랙박스 · 항목·고지·증빙 확인</title><desc id="d">Dongne Radar cover for maintenance-fee-opaque-rent</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#052e16"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="1200" height="675" fill="url(#g)" rx="28"/>
+<rect x="60.0" y="81.0" width="1080.0" height="513.0" rx="24" fill="none" stroke="#4ade80" stroke-opacity="0.35"/>
+<text x="96.0" y="182.2" fill="#4ade80" font-size="54.0" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="96.0" y="324.0" fill="#f8fafc" font-size="67.5" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">관리비 블랙박스</text>
+<text x="96.0" y="418.5" fill="#cbd5e1" font-size="47.3" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">항목·고지·증빙 확인</text>
+<path d="M 888.0 378.0 L 1080.0 378.0 M 888.0 418.5 L 1080.0 418.5 M 888.0 459.0 L 1080.0 459.0" stroke="#4ade80" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/assets/radar/monthly-rent-pressure-questions/visuals/monthly-rent-pressure-questions-card.svg
+++ b/assets/radar/monthly-rent-pressure-questions/visuals/monthly-rent-pressure-questions-card.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="t d">
+<title id="t">월세 5만 원의 함정 · 계약 전 5문 5답</title><desc id="d">Dongne Radar cover for monthly-rent-pressure-questions</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#1f2937"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="640" height="360" fill="url(#g)" rx="28"/>
+<rect x="32.0" y="43.2" width="576.0" height="273.6" rx="24" fill="none" stroke="#f59e0b" stroke-opacity="0.35"/>
+<text x="51.2" y="97.2" fill="#f59e0b" font-size="28.8" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="51.2" y="172.8" fill="#f8fafc" font-size="36.0" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">월세 5만 원의 함정</text>
+<text x="51.2" y="223.2" fill="#cbd5e1" font-size="25.2" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">계약 전 5문 5답</text>
+<path d="M 473.6 201.6 L 576.0 201.6 M 473.6 223.2 L 576.0 223.2 M 473.6 244.8 L 576.0 244.8" stroke="#f59e0b" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/assets/radar/monthly-rent-pressure-questions/visuals/monthly-rent-pressure-questions-og.svg
+++ b/assets/radar/monthly-rent-pressure-questions/visuals/monthly-rent-pressure-questions-og.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="t d">
+<title id="t">월세 5만 원의 함정 · 계약 전 5문 5답</title><desc id="d">Dongne Radar cover for monthly-rent-pressure-questions</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#1f2937"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="1200" height="675" fill="url(#g)" rx="28"/>
+<rect x="60.0" y="81.0" width="1080.0" height="513.0" rx="24" fill="none" stroke="#f59e0b" stroke-opacity="0.35"/>
+<text x="96.0" y="182.2" fill="#f59e0b" font-size="54.0" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="96.0" y="324.0" fill="#f8fafc" font-size="67.5" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">월세 5만 원의 함정</text>
+<text x="96.0" y="418.5" fill="#cbd5e1" font-size="47.3" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">계약 전 5문 5답</text>
+<path d="M 888.0 378.0 L 1080.0 378.0 M 888.0 418.5 L 1080.0 418.5 M 888.0 459.0 L 1080.0 459.0" stroke="#f59e0b" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/assets/radar/morning-routine-neighborhood-check/visuals/morning-routine-neighborhood-check-card.svg
+++ b/assets/radar/morning-routine-neighborhood-check/visuals/morning-routine-neighborhood-check-card.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="t d">
+<title id="t">아침 8시 동선 · 등교·수거·출근 충돌</title><desc id="d">Dongne Radar cover for morning-routine-neighborhood-check</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#052e16"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="640" height="360" fill="url(#g)" rx="28"/>
+<rect x="32.0" y="43.2" width="576.0" height="273.6" rx="24" fill="none" stroke="#4ade80" stroke-opacity="0.35"/>
+<text x="51.2" y="97.2" fill="#4ade80" font-size="28.8" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="51.2" y="172.8" fill="#f8fafc" font-size="36.0" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">아침 8시 동선</text>
+<text x="51.2" y="223.2" fill="#cbd5e1" font-size="25.2" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">등교·수거·출근 충돌</text>
+<path d="M 473.6 201.6 L 576.0 201.6 M 473.6 223.2 L 576.0 223.2 M 473.6 244.8 L 576.0 244.8" stroke="#4ade80" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/assets/radar/morning-routine-neighborhood-check/visuals/morning-routine-neighborhood-check-og.svg
+++ b/assets/radar/morning-routine-neighborhood-check/visuals/morning-routine-neighborhood-check-og.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="t d">
+<title id="t">아침 8시 동선 · 등교·수거·출근 충돌</title><desc id="d">Dongne Radar cover for morning-routine-neighborhood-check</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#052e16"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="1200" height="675" fill="url(#g)" rx="28"/>
+<rect x="60.0" y="81.0" width="1080.0" height="513.0" rx="24" fill="none" stroke="#4ade80" stroke-opacity="0.35"/>
+<text x="96.0" y="182.2" fill="#4ade80" font-size="54.0" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="96.0" y="324.0" fill="#f8fafc" font-size="67.5" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">아침 8시 동선</text>
+<text x="96.0" y="418.5" fill="#cbd5e1" font-size="47.3" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">등교·수거·출근 충돌</text>
+<path d="M 888.0 378.0 L 1080.0 378.0 M 888.0 418.5 L 1080.0 418.5 M 888.0 459.0 L 1080.0 459.0" stroke="#4ade80" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/assets/radar/night-noise-walk-check/visuals/night-noise-walk-check-card.svg
+++ b/assets/radar/night-noise-walk-check/visuals/night-noise-walk-check-card.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="t d">
+<title id="t">밤 10시 소음 산책 · 15분 체크 루틴</title><desc id="d">Dongne Radar cover for night-noise-walk-check</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0f172a"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="640" height="360" fill="url(#g)" rx="28"/>
+<rect x="32.0" y="43.2" width="576.0" height="273.6" rx="24" fill="none" stroke="#38bdf8" stroke-opacity="0.35"/>
+<text x="51.2" y="97.2" fill="#38bdf8" font-size="28.8" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="51.2" y="172.8" fill="#f8fafc" font-size="36.0" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">밤 10시 소음 산책</text>
+<text x="51.2" y="223.2" fill="#cbd5e1" font-size="25.2" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">15분 체크 루틴</text>
+<circle cx="537.6" cy="90.0" r="28.8" fill="#38bdf8" opacity="0.8"/>
+</svg>

--- a/assets/radar/night-noise-walk-check/visuals/night-noise-walk-check-og.svg
+++ b/assets/radar/night-noise-walk-check/visuals/night-noise-walk-check-og.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="t d">
+<title id="t">밤 10시 소음 산책 · 15분 체크 루틴</title><desc id="d">Dongne Radar cover for night-noise-walk-check</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0f172a"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="1200" height="675" fill="url(#g)" rx="28"/>
+<rect x="60.0" y="81.0" width="1080.0" height="513.0" rx="24" fill="none" stroke="#38bdf8" stroke-opacity="0.35"/>
+<text x="96.0" y="182.2" fill="#38bdf8" font-size="54.0" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="96.0" y="324.0" fill="#f8fafc" font-size="67.5" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">밤 10시 소음 산책</text>
+<text x="96.0" y="418.5" fill="#cbd5e1" font-size="47.3" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">15분 체크 루틴</text>
+<circle cx="1008.0" cy="168.8" r="54.0" fill="#38bdf8" opacity="0.8"/>
+</svg>

--- a/assets/radar/rainy-day-viewing-neighborhood-signals/visuals/rainy-day-viewing-neighborhood-signals-card.svg
+++ b/assets/radar/rainy-day-viewing-neighborhood-signals/visuals/rainy-day-viewing-neighborhood-signals-card.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="t d">
+<title id="t">비 오는 날 임장 · 젖은 동선의 경고등</title><desc id="d">Dongne Radar cover for rainy-day-viewing-neighborhood-signals</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0f172a"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="640" height="360" fill="url(#g)" rx="28"/>
+<rect x="32.0" y="43.2" width="576.0" height="273.6" rx="24" fill="none" stroke="#38bdf8" stroke-opacity="0.35"/>
+<text x="51.2" y="97.2" fill="#38bdf8" font-size="28.8" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="51.2" y="172.8" fill="#f8fafc" font-size="36.0" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">비 오는 날 임장</text>
+<text x="51.2" y="223.2" fill="#cbd5e1" font-size="25.2" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">젖은 동선의 경고등</text>
+<circle cx="537.6" cy="90.0" r="28.8" fill="#38bdf8" opacity="0.8"/>
+</svg>

--- a/assets/radar/rainy-day-viewing-neighborhood-signals/visuals/rainy-day-viewing-neighborhood-signals-og.svg
+++ b/assets/radar/rainy-day-viewing-neighborhood-signals/visuals/rainy-day-viewing-neighborhood-signals-og.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="t d">
+<title id="t">비 오는 날 임장 · 젖은 동선의 경고등</title><desc id="d">Dongne Radar cover for rainy-day-viewing-neighborhood-signals</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0f172a"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="1200" height="675" fill="url(#g)" rx="28"/>
+<rect x="60.0" y="81.0" width="1080.0" height="513.0" rx="24" fill="none" stroke="#38bdf8" stroke-opacity="0.35"/>
+<text x="96.0" y="182.2" fill="#38bdf8" font-size="54.0" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="96.0" y="324.0" fill="#f8fafc" font-size="67.5" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">비 오는 날 임장</text>
+<text x="96.0" y="418.5" fill="#cbd5e1" font-size="47.3" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">젖은 동선의 경고등</text>
+<circle cx="1008.0" cy="168.8" r="54.0" fill="#38bdf8" opacity="0.8"/>
+</svg>

--- a/assets/radar/shared-entrance-management-signals/visuals/shared-entrance-management-signals-card.svg
+++ b/assets/radar/shared-entrance-management-signals/visuals/shared-entrance-management-signals-card.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="t d">
+<title id="t">공동현관 30초 · 관리 신호 판독</title><desc id="d">Dongne Radar cover for shared-entrance-management-signals</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#052e16"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="640" height="360" fill="url(#g)" rx="28"/>
+<rect x="32.0" y="43.2" width="576.0" height="273.6" rx="24" fill="none" stroke="#4ade80" stroke-opacity="0.35"/>
+<text x="51.2" y="97.2" fill="#4ade80" font-size="28.8" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="51.2" y="172.8" fill="#f8fafc" font-size="36.0" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">공동현관 30초</text>
+<text x="51.2" y="223.2" fill="#cbd5e1" font-size="25.2" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">관리 신호 판독</text>
+<path d="M 473.6 201.6 L 576.0 201.6 M 473.6 223.2 L 576.0 223.2 M 473.6 244.8 L 576.0 244.8" stroke="#4ade80" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/assets/radar/shared-entrance-management-signals/visuals/shared-entrance-management-signals-og.svg
+++ b/assets/radar/shared-entrance-management-signals/visuals/shared-entrance-management-signals-og.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="t d">
+<title id="t">공동현관 30초 · 관리 신호 판독</title><desc id="d">Dongne Radar cover for shared-entrance-management-signals</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#052e16"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="1200" height="675" fill="url(#g)" rx="28"/>
+<rect x="60.0" y="81.0" width="1080.0" height="513.0" rx="24" fill="none" stroke="#4ade80" stroke-opacity="0.35"/>
+<text x="96.0" y="182.2" fill="#4ade80" font-size="54.0" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="96.0" y="324.0" fill="#f8fafc" font-size="67.5" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">공동현관 30초</text>
+<text x="96.0" y="418.5" fill="#cbd5e1" font-size="47.3" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">관리 신호 판독</text>
+<path d="M 888.0 378.0 L 1080.0 378.0 M 888.0 418.5 L 1080.0 418.5 M 888.0 459.0 L 1080.0 459.0" stroke="#4ade80" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/assets/radar/stair-only-fourth-floor-villa-check/visuals/stair-only-fourth-floor-villa-check-card.svg
+++ b/assets/radar/stair-only-fourth-floor-villa-check/visuals/stair-only-fourth-floor-villa-check-card.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="t d">
+<title id="t">무엘베 4층 빌라 · 계단·짐·야간 귀가</title><desc id="d">Dongne Radar cover for stair-only-fourth-floor-villa-check</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#1f2937"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="640" height="360" fill="url(#g)" rx="28"/>
+<rect x="32.0" y="43.2" width="576.0" height="273.6" rx="24" fill="none" stroke="#f59e0b" stroke-opacity="0.35"/>
+<text x="51.2" y="97.2" fill="#f59e0b" font-size="28.8" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="51.2" y="172.8" fill="#f8fafc" font-size="36.0" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">무엘베 4층 빌라</text>
+<text x="51.2" y="223.2" fill="#cbd5e1" font-size="25.2" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">계단·짐·야간 귀가</text>
+<rect x="473.6" y="187.2" width="18" height="10" fill="#f59e0b"/><rect x="489.6" y="177.2" width="18" height="10" fill="#f59e0b"/><rect x="505.6" y="167.2" width="18" height="10" fill="#f59e0b"/><rect x="521.6" y="157.2" width="18" height="10" fill="#f59e0b"/><rect x="537.6" y="147.2" width="18" height="10" fill="#f59e0b"/><rect x="553.6" y="137.2" width="18" height="10" fill="#f59e0b"/><rect x="569.6" y="127.2" width="18" height="10" fill="#f59e0b"/><rect x="585.6" y="117.2" width="18" height="10" fill="#f59e0b"/>
+</svg>

--- a/assets/radar/stair-only-fourth-floor-villa-check/visuals/stair-only-fourth-floor-villa-check-og.svg
+++ b/assets/radar/stair-only-fourth-floor-villa-check/visuals/stair-only-fourth-floor-villa-check-og.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="t d">
+<title id="t">무엘베 4층 빌라 · 계단·짐·야간 귀가</title><desc id="d">Dongne Radar cover for stair-only-fourth-floor-villa-check</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#1f2937"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="1200" height="675" fill="url(#g)" rx="28"/>
+<rect x="60.0" y="81.0" width="1080.0" height="513.0" rx="24" fill="none" stroke="#f59e0b" stroke-opacity="0.35"/>
+<text x="96.0" y="182.2" fill="#f59e0b" font-size="54.0" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="96.0" y="324.0" fill="#f8fafc" font-size="67.5" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">무엘베 4층 빌라</text>
+<text x="96.0" y="418.5" fill="#cbd5e1" font-size="47.3" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">계단·짐·야간 귀가</text>
+<rect x="888.0" y="351.0" width="18" height="10" fill="#f59e0b"/><rect x="904.0" y="341.0" width="18" height="10" fill="#f59e0b"/><rect x="920.0" y="331.0" width="18" height="10" fill="#f59e0b"/><rect x="936.0" y="321.0" width="18" height="10" fill="#f59e0b"/><rect x="952.0" y="311.0" width="18" height="10" fill="#f59e0b"/><rect x="968.0" y="301.0" width="18" height="10" fill="#f59e0b"/><rect x="984.0" y="291.0" width="18" height="10" fill="#f59e0b"/><rect x="1000.0" y="281.0" width="18" height="10" fill="#f59e0b"/>
+</svg>

--- a/assets/radar/station-to-home-night-route-check/visuals/station-to-home-night-route-check-card.svg
+++ b/assets/radar/station-to-home-night-route-check/visuals/station-to-home-night-route-check-card.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="t d">
+<title id="t">역→집 마지막 7분 · 밤길 재점검</title><desc id="d">Dongne Radar cover for station-to-home-night-route-check</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0f172a"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="640" height="360" fill="url(#g)" rx="28"/>
+<rect x="32.0" y="43.2" width="576.0" height="273.6" rx="24" fill="none" stroke="#38bdf8" stroke-opacity="0.35"/>
+<text x="51.2" y="97.2" fill="#38bdf8" font-size="28.8" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="51.2" y="172.8" fill="#f8fafc" font-size="36.0" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">역→집 마지막 7분</text>
+<text x="51.2" y="223.2" fill="#cbd5e1" font-size="25.2" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">밤길 재점검</text>
+<circle cx="537.6" cy="90.0" r="28.8" fill="#38bdf8" opacity="0.8"/>
+</svg>

--- a/assets/radar/station-to-home-night-route-check/visuals/station-to-home-night-route-check-og.svg
+++ b/assets/radar/station-to-home-night-route-check/visuals/station-to-home-night-route-check-og.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="t d">
+<title id="t">역→집 마지막 7분 · 밤길 재점검</title><desc id="d">Dongne Radar cover for station-to-home-night-route-check</desc>
+<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0f172a"/><stop offset="100%" stop-color="#020617"/></linearGradient></defs>
+<rect width="1200" height="675" fill="url(#g)" rx="28"/>
+<rect x="60.0" y="81.0" width="1080.0" height="513.0" rx="24" fill="none" stroke="#38bdf8" stroke-opacity="0.35"/>
+<text x="96.0" y="182.2" fill="#38bdf8" font-size="54.0" font-weight="700" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">DONGNE RADAR</text>
+<text x="96.0" y="324.0" fill="#f8fafc" font-size="67.5" font-weight="800" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">역→집 마지막 7분</text>
+<text x="96.0" y="418.5" fill="#cbd5e1" font-size="47.3" font-weight="600" font-family="Pretendard, Apple SD Gothic Neo, sans-serif">밤길 재점검</text>
+<circle cx="1008.0" cy="168.8" r="54.0" fill="#38bdf8" opacity="0.8"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -94,18 +94,10 @@
 <section class="article-list mixed-list radar-latest-grid">
   <div class="section-title"><h2>동네 레이더 최신 글</h2><p>계약 전 리스크와 현장 질문을 먼저 확인하세요.</p></div>
   <article class="list-card radar-card theme-night">
-  <a class="radar-card-visual scene-night" href="/radar/station-to-home-night-route-check/" aria-label="역에서 집까지 마지막 7분, 밤길을 다시 보는 법">
-    <span class="radar-thumb-label">CASE</span>
-    <strong class="radar-thumb-title">밤에 다시 보기</strong>
-    <span class="radar-thumb-subline">낮사진을 의심</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art night-art">
-      <span class="lamp-post"></span><span class="lamp-light"></span><span class="alley-road"></span>
-      <span class="window-stack"></span><span class="noise-wave wave-one"></span><span class="noise-wave wave-two"></span>
-      <span class="street-chip chip-a">출구</span><span class="street-chip chip-b">골목</span><span class="street-chip chip-c">소음</span>
-    </span>
-    </span>
-    <span class="radar-card-badge">밤길 수사</span>
+  <a class="radar-card-visual" href="/radar/station-to-home-night-route-check/" aria-label="역에서 집까지 마지막 7분, 밤길을 다시 보는 법">
+    <picture>
+      <img src="/assets/radar/station-to-home-night-route-check/visuals/station-to-home-night-route-check-card.svg" alt="역에서 집까지 마지막 7분, 밤길을 다시 보는 법 커버 이미지" width="640" height="360" loading="lazy" decoding="async" />
+    </picture>
   </a>
   <div class="radar-card-body">
     <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-05-04T13:38:57+09:00">05.04</time></div>
@@ -118,17 +110,10 @@
   </div>
 </article>
 <article class="list-card radar-card theme-filter">
-  <a class="radar-card-visual scene-filter" href="/radar/shared-entrance-management-signals/" aria-label="공동현관 앞 30초, 살 동네의 관리 신호를 읽는 법">
-    <span class="radar-thumb-label">CASE</span>
-    <strong class="radar-thumb-title">후보 줄이기</strong>
-    <span class="radar-thumb-subline">좋은 집보다 위험 신호 먼저</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art filter-art">
-      <span class="funnel"></span><span class="visual-checklist"><i>신호</i><i>질문</i><i>판단</i></span>
-      <span class="reject-card">삭제</span><span class="keep-card">보류</span>
-    </span>
-    </span>
-    <span class="radar-card-badge">계약 전 신호</span>
+  <a class="radar-card-visual" href="/radar/shared-entrance-management-signals/" aria-label="공동현관 앞 30초, 살 동네의 관리 신호를 읽는 법">
+    <picture>
+      <img src="/assets/radar/shared-entrance-management-signals/visuals/shared-entrance-management-signals-card.svg" alt="공동현관 앞 30초, 살 동네의 관리 신호를 읽는 법 커버 이미지" width="640" height="360" loading="lazy" decoding="async" />
+    </picture>
   </a>
   <div class="radar-card-body">
     <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-05-04T00:28:27+09:00">05.04</time></div>
@@ -141,18 +126,10 @@
   </div>
 </article>
 <article class="list-card radar-card theme-night">
-  <a class="radar-card-visual scene-night" href="/radar/ground-floor-home-check/" aria-label="반지하가 아닌 1층집, 계속 볼지 보류할지 보는 14분">
-    <span class="radar-thumb-label">CASE</span>
-    <strong class="radar-thumb-title">밤에 다시 보기</strong>
-    <span class="radar-thumb-subline">낮사진을 의심</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art night-art">
-      <span class="lamp-post"></span><span class="lamp-light"></span><span class="alley-road"></span>
-      <span class="window-stack"></span><span class="noise-wave wave-one"></span><span class="noise-wave wave-two"></span>
-      <span class="street-chip chip-a">출구</span><span class="street-chip chip-b">골목</span><span class="street-chip chip-c">소음</span>
-    </span>
-    </span>
-    <span class="radar-card-badge">밤길 수사</span>
+  <a class="radar-card-visual" href="/radar/ground-floor-home-check/" aria-label="반지하가 아닌 1층집, 계속 볼지 보류할지 보는 14분">
+    <picture>
+      <img src="/assets/radar/ground-floor-home-check/visuals/ground-floor-home-check-card.svg" alt="반지하가 아닌 1층집, 계속 볼지 보류할지 보는 14분 커버 이미지" width="640" height="360" loading="lazy" decoding="async" />
+    </picture>
   </a>
   <div class="radar-card-body">
     <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-05-03T17:32:19+09:00">05.03</time></div>
@@ -165,18 +142,10 @@
   </div>
 </article>
 <article class="list-card radar-card theme-night">
-  <a class="radar-card-visual scene-night" href="/radar/stair-only-fourth-floor-villa-check/" aria-label="엘리베이터 없는 4층 빌라, 계속 볼지 보류할지 보는 12분">
-    <span class="radar-thumb-label">CASE</span>
-    <strong class="radar-thumb-title">밤에 다시 보기</strong>
-    <span class="radar-thumb-subline">낮사진을 의심</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art night-art">
-      <span class="lamp-post"></span><span class="lamp-light"></span><span class="alley-road"></span>
-      <span class="window-stack"></span><span class="noise-wave wave-one"></span><span class="noise-wave wave-two"></span>
-      <span class="street-chip chip-a">출구</span><span class="street-chip chip-b">골목</span><span class="street-chip chip-c">소음</span>
-    </span>
-    </span>
-    <span class="radar-card-badge">밤길 수사</span>
+  <a class="radar-card-visual" href="/radar/stair-only-fourth-floor-villa-check/" aria-label="엘리베이터 없는 4층 빌라, 계속 볼지 보류할지 보는 12분">
+    <picture>
+      <img src="/assets/radar/stair-only-fourth-floor-villa-check/visuals/stair-only-fourth-floor-villa-check-card.svg" alt="엘리베이터 없는 4층 빌라, 계속 볼지 보류할지 보는 12분 커버 이미지" width="640" height="360" loading="lazy" decoding="async" />
+    </picture>
   </a>
   <div class="radar-card-body">
     <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-05-03T04:36:25+09:00">05.03</time></div>

--- a/main.css
+++ b/main.css
@@ -129,62 +129,9 @@ h2 { letter-spacing: -0.035em; line-height: 1.18; }
 .mixed-list { grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
 .radar-card { padding: 0; overflow: hidden; display: grid; grid-template-columns: minmax(220px, 0.42fr) minmax(0, 1fr); align-items: stretch; }
 .radar-card, .radar-card * { overflow-wrap: break-word; word-break: keep-all; }
-.radar-card-visual { position: relative; display: block; min-height: 250px; overflow: hidden; isolation: isolate; padding: 22px; color: #fff; background: linear-gradient(135deg, #211922, #573322 58%, #ff5a1f); }
-.radar-card.theme-commute .radar-card-visual { background: radial-gradient(circle at 18% 18%, rgba(147,197,253,.35), transparent 24%), linear-gradient(135deg, #0f172a, #1d4ed8 58%, #38bdf8); }
-.radar-card.theme-night .radar-card-visual { background: radial-gradient(circle at 74% 18%, rgba(255,214,165,.28), transparent 25%), linear-gradient(135deg, #160f1d, #3b1f2b 55%, #ff6b2b); }
-.radar-card.theme-fee .radar-card-visual { background: radial-gradient(circle at 18% 22%, rgba(255,255,255,.24), transparent 23%), linear-gradient(135deg, #2b2118, #7a4f12 56%, #ffb020); }
-.radar-card.theme-pressure .radar-card-visual { background: radial-gradient(circle at 75% 18%, rgba(186,230,253,.24), transparent 24%), linear-gradient(135deg, #172033, #244973 58%, #2563eb); }
-.radar-card.theme-filter .radar-card-visual { background: radial-gradient(circle at 22% 18%, rgba(187,247,208,.22), transparent 23%), linear-gradient(135deg, #15251d, #22543d 55%, #0f8b57); }
-.radar-card.theme-cafe .radar-card-visual { background: radial-gradient(circle at 20% 20%, rgba(254,240,138,.23), transparent 23%), linear-gradient(135deg, #17152b, #3b2f74 55%, #0f8b57); }
-.radar-card-visual::before { content: ""; position: absolute; inset: 16px; z-index: -2; border-radius: 28px; border: 1px solid rgba(255,255,255,.18); background-image: linear-gradient(rgba(255,255,255,.07) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.07) 1px, transparent 1px); background-size: 32px 32px; pointer-events: none; }
-.radar-card-visual::after { content: ""; position: absolute; right: -54px; bottom: -70px; z-index: -1; width: 230px; height: 230px; border-radius: 50%; background: radial-gradient(circle, rgba(255,255,255,.24), rgba(255,255,255,.05) 48%, transparent 68%); pointer-events: none; }
-.radar-thumb-label { position: relative; z-index: 3; display: inline-flex; padding: 6px 10px; border-radius: 999px; background: rgba(255,255,255,.14); border: 1px solid rgba(255,255,255,.24); font-size: 11px; font-weight: 950; letter-spacing: .08em; }
-.radar-thumb-title { position: relative; z-index: 3; display: block; max-width: 205px; margin-top: 14px; font-size: clamp(29px, 4vw, 44px); line-height: .98; letter-spacing: -.06em; text-shadow: 0 14px 34px rgba(0,0,0,.28); }
-.radar-thumb-subline { position: relative; z-index: 3; display: block; max-width: 220px; margin-top: 9px; color: rgba(255,255,255,.84); font-size: 13px; line-height: 1.35; font-weight: 850; }
-.radar-thumb-art { position: absolute; z-index: 2; right: 16px; bottom: 18px; width: min(58%, 220px); height: 58%; min-height: 132px; pointer-events: none; }
-.scene-art, .scene-art > * { position: absolute; display: block; box-sizing: border-box; }
-.scene-art { inset: 0; }
-.radar-card-badge { position: absolute; z-index: 4; left: 18px; bottom: 18px; display: inline-flex; padding: 8px 12px; border-radius: 999px; background: rgba(255,255,255,.17); border: 1px solid rgba(255,255,255,.28); backdrop-filter: blur(10px); color: #fff; font-size: 12px; font-weight: 950; }
-.time-card { left: 8px; top: 4px; padding: 10px 12px; border-radius: 18px; background: #fff; color: #0f172a; font-weight: 950; font-size: 26px; box-shadow: 0 18px 34px rgba(0,0,0,.25); }
-.rail-line { left: 12px; right: 10px; top: 78px; height: 7px; border-radius: 999px; background: linear-gradient(90deg, #fff, #93c5fd); box-shadow: 0 0 20px rgba(147,197,253,.7); }
-.station { top: 62px; min-width: 48px; padding: 7px 8px; border-radius: 999px; background: rgba(15,23,42,.78); border: 1px solid rgba(255,255,255,.28); color: #fff; font-size: 11px; text-align: center; font-weight: 950; }
-.station-a { left: 0; } .station-b { left: 47%; transform: translateX(-50%); } .station-c { right: 0; }
-.rain-mark { right: 18px; top: 12px; width: 46px; height: 72px; transform: rotate(18deg); background: repeating-linear-gradient(90deg, rgba(255,255,255,.82) 0 3px, transparent 3px 12px); opacity: .55; }
-.lamp-post { left: 22px; top: 18px; width: 10px; height: 92px; border-radius: 999px; background: rgba(255,255,255,.8); }
-.lamp-post::before { content: ""; position: absolute; left: -16px; top: -8px; width: 46px; height: 16px; border-radius: 999px; background: #ffe2a8; box-shadow: 0 0 24px rgba(255,226,168,.9); }
-.lamp-light { left: -18px; top: 18px; width: 96px; height: 104px; transform: skewX(-12deg); background: linear-gradient(120deg, rgba(255,226,168,.38), transparent 72%); clip-path: polygon(38% 0, 72% 0, 100% 100%, 0 100%); }
-.alley-road { left: 42px; right: 8px; bottom: 2px; height: 56px; transform: skewX(-20deg); border-radius: 18px; background: linear-gradient(90deg, rgba(20,16,24,.92), rgba(255,255,255,.14)); }
-.window-stack { right: 12px; top: 15px; width: 54px; height: 72px; border-radius: 16px; background: repeating-linear-gradient(180deg, rgba(255,238,190,.95) 0 9px, transparent 9px 20px), rgba(255,255,255,.13); border: 1px solid rgba(255,255,255,.2); }
-.noise-wave { right: 70px; top: 42px; width: 42px; height: 42px; border: 2px solid rgba(255,255,255,.7); border-left-color: transparent; border-bottom-color: transparent; border-radius: 50%; transform: rotate(45deg); } .wave-two { right: 60px; top: 32px; width: 66px; height: 66px; opacity: .45; }
-.street-chip, .cost-chip { padding: 6px 9px; border-radius: 999px; background: rgba(255,255,255,.9); color: #211922; font-size: 11px; font-weight: 950; box-shadow: 0 10px 20px rgba(0,0,0,.18); }
-.street-chip.chip-a { left: 4px; bottom: 12px; } .street-chip.chip-b { left: 68px; bottom: 42px; } .street-chip.chip-c { right: 2px; bottom: 14px; }
-.receipt { left: 16px; top: 4px; width: 126px; min-height: 132px; padding: 14px 12px 16px; border-radius: 18px 18px 8px 8px; background: #fffaf4; color: #2b2118; box-shadow: 0 18px 32px rgba(0,0,0,.22); }
-.receipt::after { content: ""; position: absolute; left: 0; right: 0; bottom: -9px; height: 12px; background: repeating-linear-gradient(90deg, #fffaf4 0 12px, transparent 12px 24px); }
-.receipt b, .receipt i { display: block; font-style: normal; } .receipt b { margin-bottom: 10px; font-size: 16px; } .receipt i { padding: 5px 0; border-top: 1px dashed rgba(43,33,24,.22); color: #705036; font-size: 12px; font-weight: 900; }
-.stamp { right: 8px; bottom: 28px; width: 76px; height: 76px; display: grid; place-items: center; border: 4px solid rgba(255,255,255,.9); border-radius: 50%; color: #fff; font-size: 17px; font-weight: 950; transform: rotate(-13deg); }
-.coin { right: 26px; top: 20px; width: 46px; height: 46px; border-radius: 50%; background: #ffd166; box-shadow: inset 0 0 0 7px rgba(255,255,255,.25), 0 12px 22px rgba(0,0,0,.22); } .coin-b { right: 2px; top: 52px; transform: scale(.72); }
-.calc { left: 16px; top: 8px; width: 112px; height: 128px; padding: 13px; border-radius: 22px; background: #f8fbff; box-shadow: 0 18px 34px rgba(0,0,0,.22); display: grid; grid-template-columns: repeat(3, 1fr); gap: 7px; }
-.calc b { grid-column: 1 / -1; display: block; padding: 7px 8px; border-radius: 10px; background: #172033; color: #fff; font-size: 13px; } .calc i { border-radius: 9px; background: #c7d2fe; }
-.loss-line { right: 2px; top: 8px; padding: 10px 12px; border-radius: 18px; background: #fff; color: #1d4ed8; font-size: 24px; font-weight: 950; box-shadow: 0 16px 30px rgba(0,0,0,.2); }
-.cost-chip.chip-a { right: 66px; bottom: 54px; } .cost-chip.chip-b { right: 10px; bottom: 36px; } .cost-chip.chip-c { right: 46px; bottom: 2px; }
-.funnel { left: 18px; top: 5px; width: 112px; height: 122px; background: linear-gradient(180deg, rgba(255,255,255,.9), rgba(187,247,208,.9)); clip-path: polygon(0 0, 100% 0, 66% 52%, 66% 100%, 34% 100%, 34% 52%); filter: drop-shadow(0 18px 26px rgba(0,0,0,.22)); }
-.visual-checklist { right: 4px; top: 12px; width: 94px; padding: 10px; border-radius: 18px; background: rgba(255,255,255,.92); color: #15251d; box-shadow: 0 16px 28px rgba(0,0,0,.18); } .visual-checklist i { display: block; padding: 5px 0 5px 18px; position: relative; font-style: normal; font-size: 12px; font-weight: 950; } .visual-checklist i::before { content: ""; position: absolute; left: 0; top: 10px; width: 9px; height: 5px; border-left: 2px solid #0f8b57; border-bottom: 2px solid #0f8b57; transform: rotate(-45deg); }
-.reject-card, .keep-card { bottom: 6px; padding: 8px 10px; border-radius: 14px; font-size: 13px; font-weight: 950; box-shadow: 0 12px 22px rgba(0,0,0,.2); } .reject-card { left: 4px; background: #2f2724; color: #fff; transform: rotate(-8deg); } .keep-card { right: 12px; background: #fff; color: #0f8b57; transform: rotate(7deg); }
-.awning { left: 14px; top: 12px; width: 132px; height: 36px; border-radius: 16px 16px 6px 6px; background: repeating-linear-gradient(90deg, #fff 0 18px, #ff6b2b 18px 36px); box-shadow: 0 14px 28px rgba(0,0,0,.2); }
-.storefront { left: 22px; top: 46px; width: 116px; height: 82px; border-radius: 12px 12px 20px 20px; background: rgba(255,255,255,.92); color: #17152b; display: grid; place-items: center; font-size: 17px; box-shadow: 0 16px 28px rgba(0,0,0,.18); }
-.cup { right: 10px; bottom: 6px; width: 64px; height: 68px; border-radius: 12px 12px 26px 26px; background: #fffaf4; box-shadow: inset -10px 0 rgba(15,139,87,.16), 0 16px 28px rgba(0,0,0,.2); } .cup::after { content: ""; position: absolute; right: -15px; top: 18px; width: 24px; height: 24px; border: 7px solid #fffaf4; border-left: 0; border-radius: 0 18px 18px 0; }
-.footfall { width: 12px; height: 12px; border-radius: 50%; background: #bbf7d0; box-shadow: 0 0 0 5px rgba(187,247,208,.18); } .dot-a { left: 0; bottom: 26px; } .dot-b { left: 26px; bottom: 2px; } .dot-c { left: 58px; bottom: 20px; }
-.rival-sign { right: 4px; top: 26px; padding: 6px 8px; border-radius: 999px; background: #17152b; color: #fff; font-size: 11px; font-weight: 950; border: 1px solid rgba(255,255,255,.28); }
-.radar-card-body { padding: 24px; display: flex; flex-direction: column; gap: 8px; }
-.radar-card h2 { margin: 2px 0 0; font-size: clamp(22px, 3vw, 31px); }
-.radar-card p { margin: 0; }
-.radar-card-hook { padding: 9px 11px; border-radius: 16px; background: #fff7ed; border: 1px solid #ffd2b8; color: #9a3412; font-size: 14px; line-height: 1.45; font-weight: 950; }
-.radar-card-actions { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 6px; }
-.radar-card-actions span { display: inline-flex; align-items: center; min-height: 30px; padding: 0 10px; border-radius: 999px; background: #fff7ed; border: 1px solid #ffd2b8; color: var(--orange-dark); font-size: 12px; font-weight: 950; }
-.radar-card .text-link { width: fit-content; min-height: 40px; margin-top: auto; padding: 0 13px; border-radius: 14px; background: var(--ink); color: #fff; text-decoration: none; box-shadow: 0 10px 22px rgba(33,25,34,.13); }
-.radar-card .text-link:hover { background: var(--orange); color: #fff; }
-.radar-latest-grid { grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr)); align-items: stretch; }
-.radar-latest-grid .radar-card { display: flex; flex-direction: column; min-height: 100%; }
+.radar-card-visual { display: block; overflow: hidden; border-radius: 24px; background: #0f172a; }
+.radar-card-visual picture, .radar-card-visual img { display: block; width: 100%; height: auto; }
+.radar-card-visual img { aspect-ratio: 16 / 9; object-fit: cover; }
 .radar-latest-grid .radar-card-visual { min-height: 210px; width: 100%; flex: 0 0 auto; }
 .radar-latest-grid .radar-card-body { min-width: 0; padding: 22px; flex: 1; }
 .radar-latest-grid .card-meta { gap: 8px; }
@@ -470,10 +417,7 @@ h2 { letter-spacing: -0.035em; line-height: 1.18; }
   .hero-pin span { display: none; }
   .card, .panel, .notice, .list-card, .article-content, .related-radar { border-radius: 22px; padding: 22px; }
   .radar-card { padding: 0; }
-  .radar-card-visual { min-height: 236px; padding: 19px; }
-  .radar-thumb-title { max-width: 166px; font-size: clamp(27px, 8.1vw, 36px); }
-  .radar-thumb-subline { max-width: 152px; font-size: 12px; line-height: 1.32; }
-  .radar-thumb-art { width: min(45%, 168px); right: 10px; bottom: 22px; min-height: 126px; }
+    .radar-card-visual { min-height: 0; }
   .time-card { font-size: 21px; padding: 8px 10px; }
   .rail-line { top: 82px; }
   .station { min-width: 42px; padding: 6px 7px; font-size: 10px; }

--- a/radar/index.html
+++ b/radar/index.html
@@ -74,18 +74,10 @@
 <section class="article-list">
   <div class="section-title"><h2>공개된 동네 레이더 글</h2><p>각 글은 결론보다 “계약 전 무엇을 다시 확인할지”에 맞춰 읽으면 됩니다.</p></div>
   <article class="list-card radar-card theme-night">
-  <a class="radar-card-visual scene-night" href="/radar/station-to-home-night-route-check/" aria-label="역에서 집까지 마지막 7분, 밤길을 다시 보는 법">
-    <span class="radar-thumb-label">CASE</span>
-    <strong class="radar-thumb-title">밤에 다시 보기</strong>
-    <span class="radar-thumb-subline">낮사진을 의심</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art night-art">
-      <span class="lamp-post"></span><span class="lamp-light"></span><span class="alley-road"></span>
-      <span class="window-stack"></span><span class="noise-wave wave-one"></span><span class="noise-wave wave-two"></span>
-      <span class="street-chip chip-a">출구</span><span class="street-chip chip-b">골목</span><span class="street-chip chip-c">소음</span>
-    </span>
-    </span>
-    <span class="radar-card-badge">밤길 수사</span>
+  <a class="radar-card-visual" href="/radar/station-to-home-night-route-check/" aria-label="역에서 집까지 마지막 7분, 밤길을 다시 보는 법">
+    <picture>
+      <img src="/assets/radar/station-to-home-night-route-check/visuals/station-to-home-night-route-check-card.svg" alt="역에서 집까지 마지막 7분, 밤길을 다시 보는 법 커버 이미지" width="640" height="360" loading="lazy" decoding="async" />
+    </picture>
   </a>
   <div class="radar-card-body">
     <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-05-04T13:38:57+09:00">05.04</time></div>
@@ -98,17 +90,10 @@
   </div>
 </article>
 <article class="list-card radar-card theme-filter">
-  <a class="radar-card-visual scene-filter" href="/radar/shared-entrance-management-signals/" aria-label="공동현관 앞 30초, 살 동네의 관리 신호를 읽는 법">
-    <span class="radar-thumb-label">CASE</span>
-    <strong class="radar-thumb-title">후보 줄이기</strong>
-    <span class="radar-thumb-subline">좋은 집보다 위험 신호 먼저</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art filter-art">
-      <span class="funnel"></span><span class="visual-checklist"><i>신호</i><i>질문</i><i>판단</i></span>
-      <span class="reject-card">삭제</span><span class="keep-card">보류</span>
-    </span>
-    </span>
-    <span class="radar-card-badge">계약 전 신호</span>
+  <a class="radar-card-visual" href="/radar/shared-entrance-management-signals/" aria-label="공동현관 앞 30초, 살 동네의 관리 신호를 읽는 법">
+    <picture>
+      <img src="/assets/radar/shared-entrance-management-signals/visuals/shared-entrance-management-signals-card.svg" alt="공동현관 앞 30초, 살 동네의 관리 신호를 읽는 법 커버 이미지" width="640" height="360" loading="lazy" decoding="async" />
+    </picture>
   </a>
   <div class="radar-card-body">
     <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-05-04T00:28:27+09:00">05.04</time></div>
@@ -121,18 +106,10 @@
   </div>
 </article>
 <article class="list-card radar-card theme-night">
-  <a class="radar-card-visual scene-night" href="/radar/ground-floor-home-check/" aria-label="반지하가 아닌 1층집, 계속 볼지 보류할지 보는 14분">
-    <span class="radar-thumb-label">CASE</span>
-    <strong class="radar-thumb-title">밤에 다시 보기</strong>
-    <span class="radar-thumb-subline">낮사진을 의심</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art night-art">
-      <span class="lamp-post"></span><span class="lamp-light"></span><span class="alley-road"></span>
-      <span class="window-stack"></span><span class="noise-wave wave-one"></span><span class="noise-wave wave-two"></span>
-      <span class="street-chip chip-a">출구</span><span class="street-chip chip-b">골목</span><span class="street-chip chip-c">소음</span>
-    </span>
-    </span>
-    <span class="radar-card-badge">밤길 수사</span>
+  <a class="radar-card-visual" href="/radar/ground-floor-home-check/" aria-label="반지하가 아닌 1층집, 계속 볼지 보류할지 보는 14분">
+    <picture>
+      <img src="/assets/radar/ground-floor-home-check/visuals/ground-floor-home-check-card.svg" alt="반지하가 아닌 1층집, 계속 볼지 보류할지 보는 14분 커버 이미지" width="640" height="360" loading="lazy" decoding="async" />
+    </picture>
   </a>
   <div class="radar-card-body">
     <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-05-03T17:32:19+09:00">05.03</time></div>
@@ -145,18 +122,10 @@
   </div>
 </article>
 <article class="list-card radar-card theme-night">
-  <a class="radar-card-visual scene-night" href="/radar/stair-only-fourth-floor-villa-check/" aria-label="엘리베이터 없는 4층 빌라, 계속 볼지 보류할지 보는 12분">
-    <span class="radar-thumb-label">CASE</span>
-    <strong class="radar-thumb-title">밤에 다시 보기</strong>
-    <span class="radar-thumb-subline">낮사진을 의심</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art night-art">
-      <span class="lamp-post"></span><span class="lamp-light"></span><span class="alley-road"></span>
-      <span class="window-stack"></span><span class="noise-wave wave-one"></span><span class="noise-wave wave-two"></span>
-      <span class="street-chip chip-a">출구</span><span class="street-chip chip-b">골목</span><span class="street-chip chip-c">소음</span>
-    </span>
-    </span>
-    <span class="radar-card-badge">밤길 수사</span>
+  <a class="radar-card-visual" href="/radar/stair-only-fourth-floor-villa-check/" aria-label="엘리베이터 없는 4층 빌라, 계속 볼지 보류할지 보는 12분">
+    <picture>
+      <img src="/assets/radar/stair-only-fourth-floor-villa-check/visuals/stair-only-fourth-floor-villa-check-card.svg" alt="엘리베이터 없는 4층 빌라, 계속 볼지 보류할지 보는 12분 커버 이미지" width="640" height="360" loading="lazy" decoding="async" />
+    </picture>
   </a>
   <div class="radar-card-body">
     <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-05-03T04:36:25+09:00">05.03</time></div>
@@ -169,17 +138,10 @@
   </div>
 </article>
 <article class="list-card radar-card theme-filter">
-  <a class="radar-card-visual scene-filter" href="/radar/morning-routine-neighborhood-check/" aria-label="아침 8시, 등교·수거·출근 동선이 겹치는 동네 체크">
-    <span class="radar-thumb-label">CASE</span>
-    <strong class="radar-thumb-title">후보 줄이기</strong>
-    <span class="radar-thumb-subline">좋은 집보다 위험 신호 먼저</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art filter-art">
-      <span class="funnel"></span><span class="visual-checklist"><i>신호</i><i>질문</i><i>판단</i></span>
-      <span class="reject-card">삭제</span><span class="keep-card">보류</span>
-    </span>
-    </span>
-    <span class="radar-card-badge">계약 전 신호</span>
+  <a class="radar-card-visual" href="/radar/morning-routine-neighborhood-check/" aria-label="아침 8시, 등교·수거·출근 동선이 겹치는 동네 체크">
+    <picture>
+      <img src="/assets/radar/morning-routine-neighborhood-check/visuals/morning-routine-neighborhood-check-card.svg" alt="아침 8시, 등교·수거·출근 동선이 겹치는 동네 체크 커버 이미지" width="640" height="360" loading="lazy" decoding="async" />
+    </picture>
   </a>
   <div class="radar-card-body">
     <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-05-03T02:27:08+09:00">05.03</time></div>
@@ -192,18 +154,10 @@
   </div>
 </article>
 <article class="list-card radar-card theme-night">
-  <a class="radar-card-visual scene-night" href="/radar/night-noise-walk-check/" aria-label="밤 10시, 살 동네 소음을 확인하는 15분 산책">
-    <span class="radar-thumb-label">CASE</span>
-    <strong class="radar-thumb-title">밤에 다시 보기</strong>
-    <span class="radar-thumb-subline">낮사진을 의심</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art night-art">
-      <span class="lamp-post"></span><span class="lamp-light"></span><span class="alley-road"></span>
-      <span class="window-stack"></span><span class="noise-wave wave-one"></span><span class="noise-wave wave-two"></span>
-      <span class="street-chip chip-a">출구</span><span class="street-chip chip-b">골목</span><span class="street-chip chip-c">소음</span>
-    </span>
-    </span>
-    <span class="radar-card-badge">밤길 수사</span>
+  <a class="radar-card-visual" href="/radar/night-noise-walk-check/" aria-label="밤 10시, 살 동네 소음을 확인하는 15분 산책">
+    <picture>
+      <img src="/assets/radar/night-noise-walk-check/visuals/night-noise-walk-check-card.svg" alt="밤 10시, 살 동네 소음을 확인하는 15분 산책 커버 이미지" width="640" height="360" loading="lazy" decoding="async" />
+    </picture>
   </a>
   <div class="radar-card-body">
     <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-05-03T00:03:40+09:00">05.03</time><span class="traffic-badge" title="최근 30일 조회 데이터">👁 최근 30일 1회 · 방문 1</span></div>
@@ -216,18 +170,10 @@
   </div>
 </article>
 <article class="list-card radar-card theme-night">
-  <a class="radar-card-visual scene-night" href="/radar/rainy-day-viewing-neighborhood-signals/" aria-label="비 오는 날 집 보러 갈 때 놓치는 동네 신호">
-    <span class="radar-thumb-label">CASE</span>
-    <strong class="radar-thumb-title">밤에 다시 보기</strong>
-    <span class="radar-thumb-subline">낮사진을 의심</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art night-art">
-      <span class="lamp-post"></span><span class="lamp-light"></span><span class="alley-road"></span>
-      <span class="window-stack"></span><span class="noise-wave wave-one"></span><span class="noise-wave wave-two"></span>
-      <span class="street-chip chip-a">출구</span><span class="street-chip chip-b">골목</span><span class="street-chip chip-c">소음</span>
-    </span>
-    </span>
-    <span class="radar-card-badge">밤길 수사</span>
+  <a class="radar-card-visual" href="/radar/rainy-day-viewing-neighborhood-signals/" aria-label="비 오는 날 집 보러 갈 때 놓치는 동네 신호">
+    <picture>
+      <img src="/assets/radar/rainy-day-viewing-neighborhood-signals/visuals/rainy-day-viewing-neighborhood-signals-card.svg" alt="비 오는 날 집 보러 갈 때 놓치는 동네 신호 커버 이미지" width="640" height="360" loading="lazy" decoding="async" />
+    </picture>
   </a>
   <div class="radar-card-body">
     <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-05-02T19:30:27+09:00">05.02</time></div>
@@ -240,19 +186,10 @@
   </div>
 </article>
 <article class="list-card radar-card theme-commute">
-  <a class="radar-card-visual scene-commute" href="/radar/commute-fatigue-neighborhood-check/" aria-label="지도앱 35분은 반쪽입니다: 출근길 피로 15분 체크">
-    <span class="radar-thumb-label">CASE 01</span>
-    <strong class="radar-thumb-title">35분→50분</strong>
-    <span class="radar-thumb-subline">앱 시간 말고 몸이 기억하는 시간</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art commute-art">
-      <span class="time-card">35→50</span>
-      <span class="rail-line"></span>
-      <span class="station station-a">앱</span><span class="station station-b">환승</span><span class="station station-c">마지막 도보</span>
-      <span class="rain-mark"></span>
-    </span>
-    </span>
-    <span class="radar-card-badge">출근길 함정</span>
+  <a class="radar-card-visual" href="/radar/commute-fatigue-neighborhood-check/" aria-label="지도앱 35분은 반쪽입니다: 출근길 피로 15분 체크">
+    <picture>
+      <img src="/assets/radar/commute-fatigue-neighborhood-check/visuals/commute-fatigue-neighborhood-check-card.svg" alt="지도앱 35분은 반쪽입니다: 출근길 피로 15분 체크 커버 이미지" width="640" height="360" loading="lazy" decoding="async" />
+    </picture>
   </a>
   <div class="radar-card-body">
     <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-05-02T15:29:28+09:00">05.02</time></div>
@@ -265,18 +202,10 @@
   </div>
 </article>
 <article class="list-card radar-card theme-night">
-  <a class="radar-card-visual scene-night" href="/radar/after-work-neighborhood-check/" aria-label="낮에 본 집은 반쪽입니다: 퇴근 후 20분 동네 수사">
-    <span class="radar-thumb-label">CASE 02</span>
-    <strong class="radar-thumb-title">낮사진 사기</strong>
-    <span class="radar-thumb-subline">방보다 귀가 장면을 먼저 본다</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art night-art">
-      <span class="lamp-post"></span><span class="lamp-light"></span><span class="alley-road"></span>
-      <span class="window-stack"></span><span class="noise-wave wave-one"></span><span class="noise-wave wave-two"></span>
-      <span class="street-chip chip-a">출구</span><span class="street-chip chip-b">골목</span><span class="street-chip chip-c">소음</span>
-    </span>
-    </span>
-    <span class="radar-card-badge">밤길 수사</span>
+  <a class="radar-card-visual" href="/radar/after-work-neighborhood-check/" aria-label="낮에 본 집은 반쪽입니다: 퇴근 후 20분 동네 수사">
+    <picture>
+      <img src="/assets/radar/after-work-neighborhood-check/visuals/after-work-neighborhood-check-card.svg" alt="낮에 본 집은 반쪽입니다: 퇴근 후 20분 동네 수사 커버 이미지" width="640" height="360" loading="lazy" decoding="async" />
+    </picture>
   </a>
   <div class="radar-card-body">
     <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-05-02T12:03:10+09:00">05.02</time></div>
@@ -289,17 +218,10 @@
   </div>
 </article>
 <article class="list-card radar-card theme-fee">
-  <a class="radar-card-visual scene-fee" href="/radar/maintenance-fee-opaque-rent/" aria-label="월세는 싼데 관리비가 흐리다? ‘관리비 블랙박스’ 보류법">
-    <span class="radar-thumb-label">CASE 03</span>
-    <strong class="radar-thumb-title">+α 고정비</strong>
-    <span class="radar-thumb-subline">월세 옆 빈칸을 열어 본다</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art fee-art">
-      <span class="receipt"><b>관리비</b><i>월세</i><i>공용</i><i>계절비</i></span>
-      <span class="stamp">빈칸?</span><span class="coin coin-a"></span><span class="coin coin-b"></span>
-    </span>
-    </span>
-    <span class="radar-card-badge">관리비 블랙박스</span>
+  <a class="radar-card-visual" href="/radar/maintenance-fee-opaque-rent/" aria-label="월세는 싼데 관리비가 흐리다? ‘관리비 블랙박스’ 보류법">
+    <picture>
+      <img src="/assets/radar/maintenance-fee-opaque-rent/visuals/maintenance-fee-opaque-rent-card.svg" alt="월세는 싼데 관리비가 흐리다? ‘관리비 블랙박스’ 보류법 커버 이미지" width="640" height="360" loading="lazy" decoding="async" />
+    </picture>
   </a>
   <div class="radar-card-body">
     <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-05-02T08:28:39+09:00">05.02</time></div>
@@ -312,17 +234,10 @@
   </div>
 </article>
 <article class="list-card radar-card theme-pressure">
-  <a class="radar-card-visual scene-pressure" href="/radar/monthly-rent-pressure-questions/" aria-label="월세 5만 원 싼 집이 더 비쌀 때: 계약 전 5개 질문">
-    <span class="radar-thumb-label">CASE 04</span>
-    <strong class="radar-thumb-title">5만↓ 손실↑</strong>
-    <span class="radar-thumb-subline">싼 숫자 뒤 생활비를 꺼낸다</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art pressure-art">
-      <span class="calc"><b>월세</b><i></i><i></i><i></i><i></i><i></i><i></i></span>
-      <span class="loss-line">5만↓</span><span class="cost-chip chip-a">보증금</span><span class="cost-chip chip-b">통근</span><span class="cost-chip chip-c">생활비</span>
-    </span>
-    </span>
-    <span class="radar-card-badge">월세 착시</span>
+  <a class="radar-card-visual" href="/radar/monthly-rent-pressure-questions/" aria-label="월세 5만 원 싼 집이 더 비쌀 때: 계약 전 5개 질문">
+    <picture>
+      <img src="/assets/radar/monthly-rent-pressure-questions/visuals/monthly-rent-pressure-questions-card.svg" alt="월세 5만 원 싼 집이 더 비쌀 때: 계약 전 5개 질문 커버 이미지" width="640" height="360" loading="lazy" decoding="async" />
+    </picture>
   </a>
   <div class="radar-card-body">
     <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-05-01T08:41:53+09:00">05.01</time><span class="traffic-badge" title="최근 30일 조회 데이터">👁 최근 30일 1회 · 방문 1</span></div>
@@ -335,17 +250,10 @@
   </div>
 </article>
 <article class="list-card radar-card theme-filter">
-  <a class="radar-card-visual scene-filter" href="/radar/dongne-signal-framework/" aria-label="동네 후보를 줄이는 5개 신호: 월세·전세 계약 전 레이더">
-    <span class="radar-thumb-label">CASE 05</span>
-    <strong class="radar-thumb-title">저장 말고 삭제</strong>
-    <span class="radar-thumb-subline">후보 과잉을 3곳으로 줄인다</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art filter-art">
-      <span class="funnel"></span><span class="visual-checklist"><i>예산</i><i>통근</i><i>생활권</i></span>
-      <span class="reject-card">삭제</span><span class="keep-card">보류</span>
-    </span>
-    </span>
-    <span class="radar-card-badge">후보 필터</span>
+  <a class="radar-card-visual" href="/radar/dongne-signal-framework/" aria-label="동네 후보를 줄이는 5개 신호: 월세·전세 계약 전 레이더">
+    <picture>
+      <img src="/assets/radar/dongne-signal-framework/visuals/dongne-signal-framework-card.svg" alt="동네 후보를 줄이는 5개 신호: 월세·전세 계약 전 레이더 커버 이미지" width="640" height="360" loading="lazy" decoding="async" />
+    </picture>
   </a>
   <div class="radar-card-body">
     <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-04-29T22:48:33+09:00">04.29</time><span class="traffic-badge" title="최근 30일 조회 데이터">👁 최근 30일 2회 · 방문 1</span></div>
@@ -358,18 +266,10 @@
   </div>
 </article>
 <article class="list-card radar-card theme-cafe">
-  <a class="radar-card-visual scene-cafe" href="/radar/cafe-contract-risk/" aria-label="사람 많은 상권이 꼭 좋은 자리는 아닙니다: 카페 계약 전 5개 의심">
-    <span class="radar-thumb-label">CASE 06</span>
-    <strong class="radar-thumb-title">사람≠손님</strong>
-    <span class="radar-thumb-subline">유동인구가 매출로 바뀌는지 본다</span>
-    <span class="radar-thumb-art" aria-hidden="true">
-      <span class="scene-art cafe-art">
-      <span class="awning"></span><span class="storefront"><b>CAFE?</b></span><span class="cup"></span>
-      <span class="footfall dot-a"></span><span class="footfall dot-b"></span><span class="footfall dot-c"></span>
-      <span class="rival-sign">경쟁</span>
-    </span>
-    </span>
-    <span class="radar-card-badge">상권 현장</span>
+  <a class="radar-card-visual" href="/radar/cafe-contract-risk/" aria-label="사람 많은 상권이 꼭 좋은 자리는 아닙니다: 카페 계약 전 5개 의심">
+    <picture>
+      <img src="/assets/radar/cafe-contract-risk/visuals/cafe-contract-risk-card.svg" alt="사람 많은 상권이 꼭 좋은 자리는 아닙니다: 카페 계약 전 5개 의심 커버 이미지" width="640" height="360" loading="lazy" decoding="async" />
+    </picture>
   </a>
   <div class="radar-card-body">
     <div class="card-meta"><span class="tag">동네 레이더</span><time datetime="2026-04-29T19:22:44+09:00">04.29</time><span class="traffic-badge" title="최근 30일 조회 데이터">👁 최근 30일 1회 · 방문 1</span></div>


### PR DESCRIPTION
### Motivation
- Replace fragile CSS/DOM “art” overlays with stable image covers so thumbnail typography and icons render consistently across browsers and avoid CSS text-rendering/legibility differences.
- Establish a predictable asset layout under `assets/radar/<slug>/visuals/` and produce both OG (`1200x675`) and card (`640x360`) variants for each radar post for predictable usage in lists and social metadata.
- Keep broad theme tokens (e.g. `theme-night`, `theme-filter`, `theme-commute`) while making per-post visuals unique and self-contained, and add performance-friendly image attributes (`loading`/`decoding`).

### Description
- Added standardized per-post visual directories and generated two SVG cover variants per radar slug at `assets/radar/<slug>/visuals/`: `*-og.svg` (1200×675) and `*-card.svg` (640×360) with baked-in typographic text and simple icons.
- Replaced the DOM art blocks inside `.radar-card-visual` in `index.html` and `radar/index.html` with an image-based structure `<picture><img src="/assets/radar/<slug>/visuals/<slug>-card.svg" ...></picture>` and applied `loading="lazy"` and `decoding="async"` to the card images.
- Simplified `main.css` so `.radar-card-visual` displays embedded images cleanly (`aspect-ratio: 16/9; object-fit: cover`) and removed the previous large set of CSS rules that rendered inline scene art and overlaid text.
- Preserved the `theme-*` class hooks for color tokens while moving title/subline text into the SVGs so each article can carry its own iconography and wording inside its image asset.

### Testing
- Ran the SVG generation script (Python) to create `*-og.svg` and `*-card.svg` files for each radar slug, and the script completed successfully.
- Ran the HTML replacement script (Python) to swap DOM art blocks to `<picture><img>` and the replacement completed successfully; changed files include `index.html` and `radar/index.html`.
- Verified removal of old DOM art and presence of new attributes using `rg` searches for `scene-`, `lamp-post`, `noise-wave` (no matches) and for `radar-card-visual` plus `loading="lazy"`/`decoding="async"` (matches present), all checks passed.
- Confirmed repository state with `git status` and the changes were staged and committed as part of the automated workflow (no test failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8587b7fe08324a5ac1ca994674d56)