### PR TITLE
Fix daily-pages-refresh crash (hermes /root path PermissionError)

### DIFF
--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -102,7 +102,12 @@ def configured_analytics_id() -> str:
     config_env = os.environ.get("DEALS_ANALYTICS_CONFIG")
     paths = ([Path(config_env)] if config_env else []) + ANALYTICS_CONFIG_PATHS
     for path in paths:
-        if not path or not path.exists():
+        try:
+            if not path or not path.exists():
+                continue
+        except OSError:
+            # A hermes-only path (e.g. /root/.hermes/secrets/...) is unreadable for the non-root
+            # GitHub Actions runner and raises PermissionError; skip it and fall through to repo config.
             continue
         try:
             data = json.loads(path.read_text(encoding="utf-8-sig"))


### PR DESCRIPTION
## 문제
스케줄된 Daily Pages Refresh 워크플로우가 계속 실패했습니다(run 28790919047 등). build_site.py의 configured_analytics_id()가 hermes 전용 경로 /root/.hermes/secrets/deals_google_metrics.json에 path.exists()를 호출하는데, GitHub Actions 비-root 러너에서 /root 접근이 PermissionError를 던져 빌드 전체가 크래시했습니다.

## 수정
path.exists() 검사를 try/except OSError로 감싸 읽을 수 없는 hermes 전용 경로는 건너뛰고 repo-local 설정(data/metrics/analytics_config.json)으로 폴백합니다. hermes/root 환경은 동작 불변, CI만 정상화.

## 검증
python scripts/build_site.py 로컬 실행 완료(정적 7페이지, exit 0).

LoopOffice가 운영 점검 중 자체 발행 파이프라인이 막힌 걸 발견해 올린 수정입니다.